### PR TITLE
Visually group jobs within the same GHA workflow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -184,3 +184,9 @@ code a { color: #AAA; }
 .suspect-duration {
   color: #DDA;
 }
+
+/* https://stackoverflow.com/a/25318957 */
+.job-group {
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+}

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -57,6 +57,18 @@ function objToStrMap(obj) {
   return strMap;
 }
 
+function sameGroup(job1, job2) {
+  const split1 = job1.split(' / ', 2);
+  const split2 = job2.split(' / ', 2);
+  if (split1.length !== split2.length) {
+    return false;
+  }
+  if (split1.length < 2) {
+    return true;
+  }
+  return split1[0] === split2[0];
+}
+
 export default class BuildHistoryDisplay extends Component {
   constructor(props) {
     super(props);
@@ -247,6 +259,22 @@ export default class BuildHistoryDisplay extends Component {
       <th className="rotate" key={jobName}><div className={consecutive_failure_count.has(jobName) ? "failing-header" : ""}>{summarize_job(jobName)}</div></th>
     );
 
+    const visible_job_groups = [];
+    let prevJob = null;
+    let jobGroup = [];
+    for (const foo of visible_jobs) {
+      if (prevJob && !sameGroup(prevJob, foo)) {
+        visible_job_groups.push(<colgroup className="job-group">{jobGroup}</colgroup>);
+        jobGroup = [];
+      }
+      prevJob = foo;
+      jobGroup.push(<col/>);
+    }
+    if (jobGroup) {
+      visible_job_groups.push(<colgroup className="job-group">{jobGroup}</colgroup>);
+      jobGroup = [];
+    }
+
     const rows = builds.map((build) => {
       let found = false;
       const sb_map = build.sb_map;
@@ -347,6 +375,11 @@ export default class BuildHistoryDisplay extends Component {
           </ul>
         </div>
         <table className="buildHistoryTable">
+          <colgroup>
+            <col/>
+            <col/>
+          </colgroup>
+          {visible_job_groups}
           <thead>
             <tr>
               <th className="left-cell">PR#</th>


### PR DESCRIPTION
This PR groups the columns (currently one group for each GitHub Actions workflow, and one group that contains all the CircleCI jobs) by placing a gap between them.