### PR TITLE
Fix router redirects

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import {
   Route,
   Link,
   Redirect,
+  Switch,
 } from "react-router-dom";
 
 const App = () => (
@@ -24,7 +25,7 @@ const App = () => (
     <div className="App">
       <header className="App-header">
         <h1 className="App-title">
-          <Link to="/">ci.pytorch.org HUD</Link> (
+          <Link to="/">hud.pytorch.org</Link> (
           <a href="https://github.com/pytorch/pytorch-ci-hud">GitHub</a>)
         </h1>
       </header>
@@ -92,14 +93,16 @@ const App = () => (
           </li>
         </Fragment>
       </ul>
-      <Route exact path="/">
-        <Redirect to="/build2/pytorch-master" />
-      </Route>
-      <Route path="/build" component={BuildRoute} />
-      <Route path="/build1" component={Build1Route} />
-      <Route path="/build2" component={Build2Route} />
-      <Route path="/torchbench-v0-nightly" component={TorchBenchRoute} />
-      <Route exact path="/status" component={Status} />
+      <Switch>
+        <Route path="/build" component={BuildRoute} />
+        <Route path="/build1" component={Build1Route} />
+        <Route path="/build2" component={Build2Route} />
+        <Route path="/torchbench-v0-nightly" component={TorchBenchRoute} />
+        <Route path="/status" component={Status} />
+        <Route exact path="/">
+          <Redirect to="/build2/pytorch-master" />
+        </Route>
+      </Switch>
     </div>
   </Router>
 );

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -136,7 +136,6 @@ export default class BuildHistoryDisplay extends Component {
     });
     const builds = await axios.all(requests);
     builds.reverse();
-    console.log(builds);
 
     const data = {};
 
@@ -326,7 +325,6 @@ export default class BuildHistoryDisplay extends Component {
     const rows = builds.map((build) => {
       let found = false;
       const sb_map = build.sb_map;
-      console.log(build);
 
       const status_cols = visible_jobs.map((jobName) => {
         const sb = sb_map.get(jobName);


### PR DESCRIPTION
They were missing a `Switch` so everything was falling through to the redirected page, and only clicking through the UI to the subpages worked. Now you can dial the URL for whatever page directly and it works.

Fixes #57 