### PR TITLE
Add a per-PR view

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "dependencies": {
     "@toast-ui/chart": "^4.3.4",
     "axios": "^0.21.1",
+    "bootstrap": "^4.6.0",
     "d3v4": "^4.2.2",
     "gh-pages": "^1.1.0",
     "parse-duration": "^0.1.1",
     "rc-tooltip": "^3.7.2",
-    "react": "^16.2.0",
+    "react": "^16.10.0",
+    "react-bootstrap": "^1.6.1",
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.2.2",
     "react-scripts": "^4.0.3"

--- a/src/App.css
+++ b/src/App.css
@@ -223,3 +223,7 @@ code a {
 .suspect-duration {
   color: #dda;
 }
+
+body {
+  padding: 20px;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -10,8 +10,10 @@ import QueueDisplay from "./QueueDisplay.js";
 import BuildHistoryDisplay from "./BuildHistoryDisplay.js";
 import GitHubStatusDisplay from "./GitHubStatusDisplay.js";
 import PerfHistoryDisplay from "./PerfHistoryDisplay.js";
+import PrDisplay from "./PrDisplay.js";
 import JobCorrelationHeatmap from "./JobCorrelationHeatmap.js";
 import GitHubActionsDisplay from "./GitHubActionsDisplay.js";
+import AuthorizeGitHub from "./AuthorizeGitHub.js";
 import {
   BrowserRouter as Router,
   Route,
@@ -96,8 +98,11 @@ const App = () => (
       <Switch>
         <Route path="/build" component={BuildRoute} />
         <Route path="/build1" component={Build1Route} />
+        <Route path="/pr" component={PrRoute} />
         <Route path="/build2" component={Build2Route} />
         <Route path="/torchbench-v0-nightly" component={TorchBenchRoute} />
+        <Route path="/github_logout" component={LogoutGitHub} />
+        <Route path="/authorize_github" component={AuthorizeGithubRoute} />
         <Route path="/status" component={Status} />
         <Route exact path="/">
           <Redirect to="/build2/pytorch-master" />
@@ -132,6 +137,16 @@ const Status = () => (
     <ComputerDisplay interval={1000} />
   </div>
 );
+
+const AuthorizeGithubRoute = () => {
+  return <AuthorizeGitHub />;
+};
+
+const LogoutGitHub = () => {
+  localStorage.removeItem("gh_pat");
+  console.log("logged out");
+  return <Redirect to="/"></Redirect>;
+};
 
 const Build = ({ match }) => {
   // Uhhh, am I really supposed to rob window.location here?
@@ -168,6 +183,17 @@ const Build2 = ({ match }) => {
     />
   );
 };
+
+const PrPage = ({ match }) => {
+  return <PrDisplay pr_number={parseInt(match.url.replace(/^\/pr\//, ""))} />;
+};
+
+const PrRoute = ({ match }) => (
+  <Fragment>
+    <Route exact path={match.url} component={PrPage} />
+    <Route path={`${match.url}/:segment`} component={PrRoute} />
+  </Fragment>
+);
 
 const BuildRoute = ({ match }) => (
   <Fragment>

--- a/src/AuthorizeGitHub.js
+++ b/src/AuthorizeGitHub.js
@@ -1,0 +1,75 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import React, { Component } from "react";
+
+const AUTH_SERVER = "https://auth.pytorch.org";
+
+export default class AuthorizeGitHub extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loggedin: !!localStorage.getItem("gh_pat"),
+    };
+  }
+  componentDidMount() {
+    this.update();
+  }
+
+  async update() {
+    let url = new URL(window.location.href);
+    let code = url.searchParams.get("code");
+    if (!code) {
+      return;
+    }
+    this.state.code = code;
+    let result = await fetch(`${AUTH_SERVER}/authenticate/${code}`).then((r) =>
+      r.json()
+    );
+    if (!result.token) {
+      alert("bad code passed to GitHub OAuth, sign into GitHub again");
+    } else {
+      localStorage.setItem("gh_pat", result.token);
+      this.state.loggedin = true;
+    }
+    this.setState(this.state);
+
+    // GitHub redirects back to a URL with just a ?code=... parameter, so store
+    // off to the side the place to go once logged in
+    const lastRedirect = localStorage.getItem("last_redirect");
+    if (lastRedirect) {
+      localStorage.removeItem("last_redirect");
+      if (lastRedirect != window.location.href) {
+        window.location.href = lastRedirect;
+      }
+    }
+  }
+
+  render() {
+    const existingToken = localStorage.getItem("gh_pat");
+    if (existingToken) {
+      return (
+        <div>
+          <a href="/github_logout">Log out</a>
+        </div>
+      );
+    }
+    if (!this.state.code) {
+      return (
+        <div>
+          <a href="https://github.com/login/oauth/authorize?scope=user:email&client_id=7e8b4df19d85405ac1b2">
+            Click here
+          </a>{" "}
+          to sign in to GitHub
+        </div>
+      );
+    }
+    return (
+      <div>
+        <p>Loading...</p>
+      </div>
+    );
+  }
+}

--- a/src/PrDisplay.js
+++ b/src/PrDisplay.js
@@ -1,0 +1,286 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import React, { Component } from "react";
+import Card from "react-bootstrap/Card";
+import "bootstrap/dist/css/bootstrap.min.css";
+import AuthorizeGitHub from "./AuthorizeGitHub.js";
+
+import { parseXml, formatBytes, asyncAll, s3, github } from "./utils.js";
+
+function getPrQuery(number) {
+  return `
+    {
+      repository(name: "pytorch", owner: "pytorch") {
+        pullRequest(number: ${number}) {
+          title
+          number
+          url
+          commits(last: 1) {
+            nodes {
+              commit {
+                checkSuites(last: 100) {
+                  nodes {
+                    databaseId
+                    workflowRun {
+                      runNumber
+                      id
+                      databaseId
+                      workflow {
+                        name
+                      }
+                      url
+                    }
+                    checkRuns(last: 100) {
+                      nodes {
+                        name
+                        title
+                        text
+                        detailsUrl
+                        summary
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+}
+
+export default class PrDisplay extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      pr_number: this.props.pr_number,
+    };
+  }
+  componentDidMount() {
+    this.update();
+  }
+
+  extractItem(result, key) {
+    // Some of the stuff from s3 can come in as a single object or an array,
+    // so unpack that here
+    if (!result[key]) {
+      return null;
+    }
+
+    if (Array.isArray(result[key])) {
+      return result[key];
+    }
+    return [result[key]];
+  }
+
+  async update() {
+    // Set some global persistent state to redirect back to this window for log
+    // ins
+    localStorage.setItem("last_redirect", window.location.href);
+
+    // Fetch the PR's info from GitHub's GraphQL API
+    localStorage.getItem("gh_pat");
+    if (!localStorage.getItem("gh_pat")) {
+      return;
+    }
+    let pr_result = await github.graphql(getPrQuery(this.state.pr_number));
+    this.state.pr = pr_result.repository.pullRequest;
+
+    // The GraphQL API doesn't have any types for artifacts (at least as far as
+    // I can tell), so we have to fall back to iterating through them all via
+    // the v3 JSON API
+    let workflow_runs = this.state.pr.commits.nodes[0].commit.checkSuites.nodes;
+    workflow_runs = workflow_runs.filter((x) => x.workflowRun);
+    await asyncAll(
+      workflow_runs.map((run) => {
+        return async () => {
+          let id = run.workflowRun.databaseId;
+          run.artifacts = await github.json(
+            `repos/pytorch/pytorch/actions/runs/${id}/artifacts`
+          );
+        };
+      })
+    );
+
+    this.state.runs = workflow_runs;
+    this.setState(this.state);
+
+    // Go through all the runs and check if there is a prefix for the workflow
+    // run in S3 (indicating that there are some relevant artifacts stored
+    // there)
+    let promises = this.state.runs.map((run) => {
+      run.s3_artifacts = [];
+      return async () => {
+        // Check that the workflow run exists
+        let result = await s3(`pytorch/pytorch/${run.workflowRun.databaseId}/`);
+
+        let prefixes = this.extractItem(
+          result.ListBucketResult,
+          "CommonPrefixes"
+        );
+
+        // If anything was found, go through the results and add the items to
+        // the 'run' object in place
+        if (prefixes && prefixes.length > 0) {
+          for (const prefixItem of prefixes) {
+            let prefix = prefixItem.Prefix["#text"];
+            let result = await s3(prefix);
+            let contents = this.extractItem(
+              result.ListBucketResult,
+              "Contents"
+            );
+            for (const content of contents) {
+              run.s3_artifacts.push(content);
+            }
+          }
+        }
+      };
+    });
+    await asyncAll(promises);
+    this.setState(this.state);
+  }
+
+  render() {
+    let runs = undefined;
+    if (this.state.runs) {
+      runs = [];
+
+      // Render all of the check runs as a list
+      for (const [run_index, run] of this.state.runs.entries()) {
+        const checks = [];
+        for (const [index, check] of run.checkRuns.nodes.entries()) {
+          checks.push(
+            <div key={"check-run-" + index}>
+              - <a href={check.detailsUrl}>{check.name}</a>
+            </div>
+          );
+        }
+
+        let artifacts = [];
+        function makeArtifact(args) {
+          if (args.expired) {
+            return (
+              <div key={`${args.kind}-${args.index}`}>
+                <span>
+                  [{args.kind}] {args.name}
+                </span>{" "}
+                <span>({formatBytes(args.size_in_bytes)}) (expired)</span>
+              </div>
+            );
+          } else {
+            return (
+              <div key={`${args.kind}-${args.index}`}>
+                <a href={args.url}>
+                  [{args.kind}] {args.name}
+                </a>{" "}
+                <span>({formatBytes(args.size_in_bytes)})</span>
+              </div>
+            );
+          }
+        }
+
+        // List out artifacts hosted on GitHub
+        if (run.artifacts) {
+          for (const [index, artifact] of run.artifacts.artifacts.entries()) {
+            // The URL in the response is for the API, not browsers, so make it
+            // manually
+            let url = `https://github.com/pytorch/pytorch/suites/${run.databaseId}/artifacts/${artifact.id}`;
+            artifacts.push(
+              makeArtifact({
+                kind: "gha",
+                index: index,
+                name: artifact.name,
+                size_in_bytes: artifact.size_in_bytes,
+                url: url,
+                expired: artifact.expired,
+              })
+            );
+          }
+        }
+
+        // List out artifacts from s3
+        if (run.s3_artifacts) {
+          for (const [index, artifact] of run.s3_artifacts.entries()) {
+            let prefix = artifact.Key["#text"];
+
+            artifacts.push(
+              makeArtifact({
+                kind: "s3",
+                index: index,
+                name: prefix.split("/").slice(-1),
+                size_in_bytes: parseInt(artifact.Size["#text"]),
+                url: `https://gha-artifacts.s3.amazonaws.com/${prefix}`,
+                expired: false,
+              })
+            );
+          }
+        }
+
+        // If there were any artifacts, set up the 'div' to show them
+        let artifactsElement = <div></div>;
+        if (artifacts.length > 0) {
+          artifactsElement = (
+            <div style={{ padding: "6px" }}>
+              <h5>Artifacts</h5>
+              {artifacts}
+            </div>
+          );
+        }
+
+        let checksElement = <div></div>;
+        if (checks.length > 0) {
+          checksElement = (
+            <div style={{ padding: "6px" }}>
+              <h5>Checks</h5>
+              {checks}
+            </div>
+          );
+        }
+
+        // Wrap up everything in a card
+        const card = (
+          <Card key={"card-" + run_index}>
+            <Card.Body>
+              <Card.Title>
+                <a href={run.workflowRun.url}>
+                  {run.workflowRun.workflow.name}
+                </a>
+              </Card.Title>
+              <div>
+                {checksElement}
+                {artifactsElement}
+              </div>
+            </Card.Body>
+          </Card>
+        );
+        runs.push(card);
+      }
+    }
+
+    return (
+      <div>
+        <AuthorizeGitHub />
+
+        <h2>
+          <a
+            href={
+              "https://github.com/pytorch/pytorch/pull/" + this.state.pr_number
+            }
+          >
+            PR #{this.state.pr_number}
+          </a>
+        </h2>
+        <p>
+          {this.state.pr
+            ? this.state.pr.title
+            : "loading (make sure you are signed in)..."}
+        </p>
+        <div>{runs}</div>
+      </div>
+    );
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,113 @@
+// see https://github.com/qoomon/aws-s3-bucket-browser/blob/937147179a9284dc8d98e7a6d52f60e8fdcd7231/index.html#L430
+export function formatBytes(size) {
+  if (!size) {
+    return "-";
+  }
+  const KB = 1024;
+  if (size < KB) {
+    return size + "  B";
+  }
+  const MB = 1000000;
+  if (size < MB) {
+    return (size / KB).toFixed(0) + " KB";
+  }
+  const GB = 1000000000;
+  if (size < GB) {
+    return (size / MB).toFixed(2) + " MB";
+  }
+  return (size / GB).toFixed(2) + " GB";
+}
+
+// see https://stackoverflow.com/a/19448718
+export function parseXml(xml, arrayTags) {
+  let dom = null;
+  if (window.DOMParser) dom = new DOMParser().parseFromString(xml, "text/xml");
+  else if (window.ActiveXObject) {
+    dom = new ActiveXObject("Microsoft.XMLDOM");
+    dom.async = false;
+    if (!dom.loadXML(xml))
+      throw dom.parseError.reason + " " + dom.parseError.srcText;
+  } else throw new Error("cannot parse xml string!");
+
+  function parseNode(xmlNode, result) {
+    if (xmlNode.nodeName == "#text") {
+      let v = xmlNode.nodeValue;
+      if (v.trim()) result["#text"] = v;
+      return;
+    }
+
+    let jsonNode = {},
+      existing = result[xmlNode.nodeName];
+    if (existing) {
+      if (!Array.isArray(existing))
+        result[xmlNode.nodeName] = [existing, jsonNode];
+      else result[xmlNode.nodeName].push(jsonNode);
+    } else {
+      if (arrayTags && arrayTags.indexOf(xmlNode.nodeName) != -1)
+        result[xmlNode.nodeName] = [jsonNode];
+      else result[xmlNode.nodeName] = jsonNode;
+    }
+
+    if (xmlNode.attributes)
+      for (let attribute of xmlNode.attributes)
+        jsonNode[attribute.nodeName] = attribute.nodeValue;
+
+    for (let node of xmlNode.childNodes) parseNode(node, jsonNode);
+  }
+
+  let result = {};
+  for (let node of dom.childNodes) parseNode(node, result);
+
+  return result;
+}
+
+export async function asyncAll(functions) {
+  // Run a list of arg-less async functions
+  let invoked = functions.map((f) => f());
+  return await Promise.all(invoked);
+}
+
+async function github_graphql(query) {
+  // Query the GitHub GraphQL API
+  const pat = localStorage.getItem("gh_pat");
+  const result = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: "token " + pat,
+    },
+    body: JSON.stringify({ query: query }),
+  });
+  return (await result.json()).data;
+}
+
+export async function github_json(url) {
+  // Query the GitHub JSON API
+  const pat = localStorage.getItem("gh_pat");
+  const result = await fetch("https://api.github.com/" + url, {
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      Authorization: "token " + pat,
+    },
+  });
+  return await result.json();
+}
+
+export let github = {
+  graphql: github_graphql,
+  json: github_json,
+};
+
+export async function s3(prefix) {
+  // List the gha-artifacts S3 bucket by a specific prefix
+  return await fetch(
+    "https://gha-artifacts.s3.amazonaws.com/?" +
+      new URLSearchParams({
+        "list-type": 2,
+        delimiter: "/",
+        prefix: prefix,
+        "max-keys": 50,
+      })
+  )
+    .then((a) => a.text())
+    .then((a) => parseXml(a));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,7 +1158,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.13.8", "@babel/runtime@^7.14.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
@@ -1494,6 +1494,24 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@popperjs/core@^2.8.6":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+
+"@restart/context@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@restart/context/-/context-2.1.4.tgz#a99d87c299a34c28bd85bb489cb07bfd23149c02"
+  integrity sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==
+
+"@restart/hooks@^0.3.26":
+  version "0.3.26"
+  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.3.26.tgz#ade155a7b0b014ef1073391dda46972c3a14a129"
+  integrity sha512-7Hwk2ZMYm+JLWcb7R9qIXk1OoUg1Z+saKWqZXlrvFwT3w6UArVNWgxYOzf+PJoK9zZejp8okPAKTctthhXLt5g==
+  dependencies:
+    lodash "^4.17.20"
+    lodash-es "^4.17.20"
+
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
@@ -1728,6 +1746,11 @@
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
   integrity sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==
 
+"@types/invariant@^2.2.33":
+  version "2.2.34"
+  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.34.tgz#05e4f79f465c2007884374d4795452f995720bbe"
+  integrity sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -1782,10 +1805,31 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
   integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
+"@types/prop-types@*", "@types/prop-types@^15.7.3":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
+
+"@types/react-transition-group@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
+  integrity sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@>=16.14.8", "@types/react@>=16.9.11":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
+  integrity sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -1793,6 +1837,11 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -1815,6 +1864,11 @@
   integrity sha512-EGkrJD5Uy+Pg0NUR8uA4bJ5WMfljyad0G+784vLCNUkD+QwOJXUbBYExXfVGf7YtyzdQp3L/XMYcliB987kL5Q==
   dependencies:
     source-map "^0.6.1"
+
+"@types/warning@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
+  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
 "@types/webpack-sources@*":
   version "2.1.0"
@@ -2804,6 +2858,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"
+  integrity sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3218,7 +3277,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.6:
+classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -3834,6 +3893,11 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
+csstype@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
+  integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -4418,6 +4482,14 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1, dom-helpers@^5.2.0, dom-helpers@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -7241,6 +7313,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -9130,6 +9207,14 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+prop-types-extra@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.1.tgz#58c3b74cbfbb95d304625975aa2f0848329a010b"
+  integrity sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==
+  dependencies:
+    react-is "^16.3.2"
+    warning "^4.0.0"
+
 prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -9357,6 +9442,29 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
+react-bootstrap@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-1.6.1.tgz#c5493c028ede885826b72eb31e66f6f0a52ab007"
+  integrity sha512-ojEPQ6OtyIMdLg0Smofk+85PKN6MLKQX3bU0Vwmok/4yNa8DQ2vCGhO2IgHJvT+ERQZ4X+gAQcdn6msAHSwLBg==
+  dependencies:
+    "@babel/runtime" "^7.14.0"
+    "@restart/context" "^2.1.4"
+    "@restart/hooks" "^0.3.26"
+    "@types/invariant" "^2.2.33"
+    "@types/prop-types" "^15.7.3"
+    "@types/react" ">=16.14.8"
+    "@types/react-transition-group" "^4.4.1"
+    "@types/warning" "^3.0.0"
+    classnames "^2.3.1"
+    dom-helpers "^5.2.1"
+    invariant "^2.2.4"
+    prop-types "^15.7.2"
+    prop-types-extra "^1.1.0"
+    react-overlays "^5.0.1"
+    react-transition-group "^4.4.1"
+    uncontrollable "^7.2.1"
+    warning "^4.0.3"
+
 react-dev-utils@^11.0.3:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.4.tgz#a7ccb60257a1ca2e0efe7a83e38e6700d17aa37a"
@@ -9402,7 +9510,7 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-is@^16.12.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.3.2, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9416,6 +9524,20 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-overlays@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-5.0.1.tgz#7e2c3cd3c0538048b0b7451d203b1289c561b7f2"
+  integrity sha512-plwUJieTBbLSrgvQ4OkkbTD/deXgxiJdNuKzo6n1RWE3OVnQIU5hffCGS/nvIuu6LpXFs2majbzaXY8rcUVdWA==
+  dependencies:
+    "@babel/runtime" "^7.13.8"
+    "@popperjs/core" "^2.8.6"
+    "@restart/hooks" "^0.3.26"
+    "@types/warning" "^3.0.0"
+    dom-helpers "^5.2.0"
+    prop-types "^15.7.2"
+    uncontrollable "^7.2.1"
+    warning "^4.0.3"
 
 react-refresh@^0.8.3:
   version "0.8.3"
@@ -9513,7 +9635,17 @@ react-scripts@^4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react@^16.2.0:
+react-transition-group@^4.4.1:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
+react@^16.10.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
@@ -11076,6 +11208,16 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
+uncontrollable@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.2.1.tgz#1fa70ba0c57a14d5f78905d533cf63916dc75738"
+  integrity sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    "@types/react" ">=16.9.11"
+    invariant "^2.2.4"
+    react-lifecycles-compat "^3.0.4"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -11335,7 +11477,7 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-warning@^4.0.1:
+warning@^4.0.0, warning@^4.0.1, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
This is inspired by https://prow.k8s.io/, which provides an external page for information about PRs. We can add basically whatever we want here which frees us from being locked into GitHub comments (e.g. with Dr. CI). For now it's pretty basic and just shows artifacts (both on GitHub and in S3) for GitHub Action jobs for the pr at `hud.pytorch.org/pr/<number>`.

There's also a bit to get authenticated with GitHub via OAuth, which from what I can tell requires something like https://github.com/prose/gatekeeper. This is spun up in https://github.com/pytorch/test-infra/pull/24 (and already manually deployed)

This also pulls in bootstrap and makes the default font sans-serif site-wide

Fixes https://github.com/pytorch/pytorch/issues/59403

![image](https://user-images.githubusercontent.com/9407960/121424113-d8034d00-c925-11eb-9b9f-ab453036b100.png)
