### PR TITLE
Remove tooltip parent on hide

### DIFF
--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -342,13 +342,14 @@ export default class BuildHistoryDisplay extends Component {
             </a>
           );
         }
+
         return (
           <Tooltip
             key={jobName}
             overlay={jobName}
             mouseLeaveDelay={0}
             placement="rightTop"
-            destroyTooltipOnHide={true}
+            destroyTooltipOnHide={{ keepParent: false }}
           >
             <td
               key={jobName}


### PR DESCRIPTION
Without this [option](https://www.npmjs.com/package/rc-tooltip) the tooltips never get deleted fully and the page slows to a crawl and makes my laptop sad

![image](https://user-images.githubusercontent.com/9407960/121428799-12231d80-c92b-11eb-8013-dfdaee4c55b6.png)
