### PR TITLE
Remove separation of binary builds / normal builds

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,8 +41,6 @@ const App = () => (
                 <Link to={`/build2/${e}-${trigger}`}>
                   {e}-{trigger}
                 </Link>
-                &nbsp; (
-                <Link to={`/build2/${e}-${trigger}?mode=nightly`}>binary</Link>)
               </li>
             ))}
           </Fragment>
@@ -175,12 +173,10 @@ const Build1 = ({ match }) => {
 
 const Build2 = ({ match }) => {
   // Uhhh, am I really supposed to rob window.location here?
-  const query = new URLSearchParams(window.location.search);
   return (
     <GitHubStatusDisplay
       interval={60000}
       job={match.url.replace(/^\/build2\//, "")}
-      mode={query.get("mode")}
     />
   );
 };

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -105,10 +105,7 @@ export default class BuildHistoryDisplay extends Component {
         showServiceJobs: this.state.showServiceJobs,
       })
     );
-    if (
-      this.props.job !== prevProps.job ||
-      this.props.mode !== prevProps.mode
-    ) {
+    if (this.props.job !== prevProps.job) {
       this.setState(this.initialState());
       this.update();
     }
@@ -142,23 +139,10 @@ export default class BuildHistoryDisplay extends Component {
     data.updateTime = new Date();
     data.connectedIn = data.updateTime - currentTime;
 
-    const props_mode = this.props.mode;
-
     const known_jobs_set = new Set();
     builds.forEach((build) => {
       build.sb_map.forEach((sb, job_name) => {
-        const nightly_candidates =
-          job_name.includes("binary_") ||
-          job_name.includes("smoke_") ||
-          job_name.includes("nightly_") ||
-          job_name.includes("nigthly_");
-        const is_nightly = nightly_candidates && !nightly_run_on_pr(job_name);
-        if (
-          (props_mode !== "nightly" && !is_nightly) ||
-          (props_mode === "nightly" && is_nightly)
-        ) {
-          known_jobs_set.add(job_name);
-        }
+        known_jobs_set.add(job_name);
       });
     });
 


### PR DESCRIPTION
Having them separate makes it hard to answer the question: "is master OK for this commit?"

This combines them into a single view with the intention that users use the filter box for paring down the data to things they're interested in.
