### PR TITLE
Add commits support to PR page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.
 
+## Using Deploy Previews
+
+Log-ins don't work on the Netlify deploy previews since the GitHub app has hud.pytorch.org hardcoded as its callback URL. To see changes that require the GitHub API in a preview you can manually copy your OAuth token. In the JS console on hud.pytorch.org, run `localStorage.getItem("gh_pat")`. Then in the preview's console, run `localStorage.setItem("gh_pat", "<the token>")`.
+
 ## License
 By contributing to pytorch-ci-hud, you agree that your contributions will be licensed
 under the LICENSE file in the root directory of this source tree.

--- a/src/App.js
+++ b/src/App.js
@@ -100,6 +100,7 @@ const App = () => (
         <Route path="/build" component={BuildRoute} />
         <Route path="/build1" component={Build1Route} />
         <Route path="/pr" component={PrRoute} />
+        <Route path="/commit/:segment" component={CommitPage} />
         <Route path="/build2" component={Build2Route} />
         <Route path="/torchbench-v0-nightly" component={TorchBenchRoute} />
         <Route path="/github_logout" component={LogoutGitHub} />
@@ -108,6 +109,7 @@ const App = () => (
         <Route exact path="/">
           <Redirect to="/build2/pytorch-master" />
         </Route>
+        <Route path="*" exact={true} component={RouteNotFound} />
       </Switch>
     </div>
   </Router>
@@ -193,6 +195,21 @@ const PrRoute = ({ match }) => (
   <Fragment>
     <Route exact path={match.url} component={PrPage} />
     <Route path={`${match.url}/:segment`} component={PrRoute} />
+  </Fragment>
+);
+
+const CommitPage = ({ match }) => {
+  return <PrDisplay commit_hash={match.url.replace(/^\/commit\//, "")} />;
+};
+
+const RouteNotFound = ({ match }) => {
+  return <p>Route not found: {match.url}</p>;
+};
+
+const CommitRoute = ({ match }) => (
+  <Fragment>
+    <Route exact path={match.url} component={CommitPage} />
+    <Route path={`${match.url}/:segment`} component={CommitRoute} />
   </Fragment>
 );
 

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -423,7 +423,9 @@ export default class BuildHistoryDisplay extends Component {
 
       const desc = (
         <div key={build.id}>
-          {drop_pr_number(build.message).split("\n")[0]}{" "}
+          <a style={{ color: "#003d7f" }} href={`/commit/${build.id}`}>
+            {drop_pr_number(build.message).split("\n")[0]}{" "}
+          </a>
           <code>
             <a
               href={"https://github.com/pytorch/pytorch/commit/" + build.id}

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,6 +81,9 @@ async function github_graphql(query) {
     },
     body: JSON.stringify({ query: query }),
   });
+  if (result.status !== 200) {
+    throw `Error fetching data from GitHub: ${await result.text()}`;
+  }
   return (await result.json()).data;
 }
 


### PR DESCRIPTION
This adds a couple checks to the PR page so that it can work with a commit hash in addition to a PR number. It's linked from the main build status page on the description.

see [preview usage note](https://github.com/pytorch/pytorch-ci-hud/blob/commit_page/CONTRIBUTING.md#using-deploy-previews)