### PR TITLE
Group related jobs into a single column

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "gh-pages": "^1.1.0",
     "highlight.js": "^11.0.1",
     "parse-duration": "^0.1.1",
-    "rc-tooltip": "^3.7.2",
+    "rc-tooltip": "^5.1.1",
     "react": "^16.10.0",
     "react-bootstrap": "^1.6.1",
     "react-dom": "^16.2.0",

--- a/src/App.css
+++ b/src/App.css
@@ -39,14 +39,21 @@ td {
 
 .buildHistoryTable td {
   border: 0;
+  padding-right: 0.15em;
 }
 
 .buildHistoryTable th {
   border: 0;
 }
 
-.buildHistoryTable tr:hover {
+.buildHistoryTable tbody tr:hover {
   background: #ccc;
+}
+
+.icon-cell {
+  text-align: right;
+  font-family: sans-serif;
+  padding: 0;
 }
 
 .icon-cell:hover {
@@ -99,6 +106,10 @@ th.rotate > div.failing-header {
   color: #c00;
   font-weight: bold;
 }
+.failing-text {
+  color: #c00;
+  font-weight: bold;
+}
 th.rotate > div.master-only-header {
   color: #909;
 }
@@ -120,6 +131,16 @@ code a {
 .menu li {
   display: inline;
   margin-right: 1em;
+}
+
+.menu li > input {
+  margin-right: 5px;
+}
+
+.display-cell {
+  cursor: pointer;
+  text-align: center;
+  width: 1em;
 }
 
 .deprecated-menu li {

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -8,6 +8,7 @@ import AsOf from "./AsOf.js";
 import { summarize_job, summarize_date } from "./Summarize.js";
 import Tooltip from "rc-tooltip";
 import axios from "axios";
+import { BsFillCaretRightFill, BsFillCaretDownFill } from "react-icons/all";
 
 const binary_and_smoke_tests_on_pr = [
   "binary_linux_manywheel_2_7mu_cpu_devtoolset7_build",
@@ -27,6 +28,22 @@ const binary_and_smoke_tests_on_pr = [
 
 function nightly_run_on_pr(job_name) {
   return binary_and_smoke_tests_on_pr.some((n) => job_name.includes(n));
+}
+
+function array_move(arr, old_index, new_index) {
+  while (old_index < 0) {
+    old_index += arr.length;
+  }
+  while (new_index < 0) {
+    new_index += arr.length;
+  }
+  if (new_index >= arr.length) {
+    var k = new_index - arr.length + 1;
+    while (k--) {
+      arr.push(undefined);
+    }
+  }
+  arr.splice(new_index, 0, arr.splice(old_index, 1)[0]);
 }
 
 function is_success(result) {
@@ -80,13 +97,16 @@ export default class BuildHistoryDisplay extends Component {
     }
     if (!("showNotifications" in prefs)) prefs["showNotifications"] = true;
     if (!("showServiceJobs" in prefs)) prefs["showServiceJobs"] = true;
+    if (!("groupJobs" in prefs)) prefs["groupJobs"] = true;
     return {
       builds: [],
       known_jobs: [],
+      showGroups: [],
       currentTime: new Date(),
       updateTime: new Date(0),
       showNotifications: prefs.showNotifications,
       showServiceJobs: prefs.showServiceJobs,
+      groupJobs: prefs.groupJobs,
       jobNameFilter: "",
     };
   }
@@ -103,6 +123,7 @@ export default class BuildHistoryDisplay extends Component {
       JSON.stringify({
         showNotifications: this.state.showNotifications,
         showServiceJobs: this.state.showServiceJobs,
+        groupJobs: this.state.groupJobs,
       })
     );
     if (
@@ -274,6 +295,135 @@ export default class BuildHistoryDisplay extends Component {
   }
 
   render() {
+    let groups = [
+      {
+        regex: /Lint/,
+        name: "Lint Jobs",
+      },
+      {
+        regex: /(\(periodic-pytorch)|(ci\/circleci: periodic_pytorch)/,
+        name: "Periodic Jobs",
+      },
+      {
+        regex: /Linux CI \(pytorch-linux-/,
+        name: "Linux GitHub Actions",
+      },
+      {
+        regex:
+          /(Add annotations )|(Close stale pull requests)|(Label PRs & Issues)|(Triage )|(Update S3 HTML indices)|(codecov\/project)/,
+        name: "Annotations and labeling",
+      },
+      {
+        regex:
+          /(ci\/circleci: docker-pytorch-)|(ci\/circleci: ecr_gc_job_)|(ci\/circleci: docker_for_ecr_gc_build_job)|(Garbage Collect ECR Images)/,
+        name: "Docker",
+      },
+      {
+        regex: /Windows CI \(pytorch-/,
+        name: "GitHub Actions Windows",
+      },
+      {
+        regex: / \/ calculate-docker-image/,
+        name: "GitHub calculate-docker-image",
+      },
+      {
+        regex: /ci\/circleci: pytorch_ios_/,
+        name: "ci/circleci: pytorch_ios",
+      },
+      {
+        regex:
+          /(ci\/circleci: pytorch_parallelnative_)|(ci\/circleci: pytorch_paralleltbb_)/,
+        name: "Parallel",
+      },
+      {
+        regex:
+          /(ci\/circleci: pytorch_cpp_doc_build)|(ci\/circleci: pytorch_cpp_doc_test)|(pytorch_python_doc_build)|(pytorch_doc_test)/,
+        name: "Docs",
+      },
+      {
+        regex: /ci\/circleci: pytorch_linux_bionic_cuda10_2_cudnn7_py3_9_gcc7_/,
+        name: "ci/circleci: pytorch_linux_bionic_cuda10_2_cudnn7_py3_9_gcc7",
+      },
+      {
+        regex: /ci\/circleci: pytorch_linux_xenial_cuda10_2_cudnn7_py3_/,
+        name: "ci/circleci: pytorch_linux_xenial_cuda10_2_cudnn7_py3",
+      },
+      {
+        regex: /ci\/circleci: pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_/,
+        name: "ci/circleci: pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7",
+      },
+      {
+        regex:
+          /(ci\/circleci: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_)|(ci\/circleci: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-)/,
+        name: "ci/circleci: pytorch_linux_xenial_py3_clang5_android_ndk",
+      },
+      {
+        regex: /ci\/circleci: pytorch_linux_xenial_py3_6_gcc7_build/,
+        name: "ci/circleci: pytorch_linux_xenial_py3_clang5_asan_build",
+      },
+      {
+        regex: /ci\/circleci: pytorch_linux_xenial_py3_clang5_mobile_/,
+        name: "ci/circleci: pytorch_linux_xenial_py3_clang5_mobile",
+      },
+      {
+        regex: /ci\/circleci: pytorch_linux_xenial_py3_clang7_onnx_/,
+        name: "ci/circleci: pytorch_linux_xenial_py3_clang7_onnx",
+      },
+      {
+        regex: /ci\/circleci: pytorch_linux_xenial_py3_clang5_asan_/,
+        name: "ci/circleci: pytorch_linux_xenial_py3_clang5_asan",
+      },
+      {
+        regex: /ci\/circleci: pytorch_linux_xenial_py3_6_gcc7_/,
+        name: "ci/circleci: pytorch_linux_xenial_py3_6_gcc7",
+      },
+      {
+        regex: /ci\/circleci: pytorch_macos_10_13_py3_/,
+        name: "ci/circleci: pytorch_macos_10_13_py3",
+      },
+      {
+        regex: /ci\/circleci: pytorch_linux_xenial_py3_6_gcc5_4_/,
+        name: "ci/circleci: pytorch_linux_xenial_py3_6_gcc5_4",
+      },
+    ];
+
+    // Initialize the groups
+    for (const group of groups) {
+      group.jobNames = [];
+    }
+
+    if (!this.state.groupJobs) {
+      groups = [];
+    }
+
+    const findGroup = (jobName) => {
+      for (const group of groups) {
+        if (jobName.match(group.regex)) {
+          return group;
+        }
+      }
+      return null;
+    };
+
+    const groupIsExpanded = (group) => {
+      for (const stateGroup of this.state.showGroups) {
+        if (stateGroup.name === group.name) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const groupIsFailing = (group) => {
+      for (const jobName of group.jobNames) {
+        if (this.state.consecutive_failure_count.has(jobName)) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
     function result_icon(result) {
       if (is_success(result))
         return (
@@ -322,40 +472,240 @@ export default class BuildHistoryDisplay extends Component {
     let builds = this.state.builds;
     let consecutive_failure_count = this.state.consecutive_failure_count;
 
-    const visible_jobs = this.state.known_jobs.filter((name) =>
+    const visibleJobs = this.state.known_jobs.filter((name) =>
       this.shouldShowJob(name)
     );
-    const visible_jobs_head = visible_jobs.map((jobName) => (
-      <th className="rotate" key={jobName}>
-        <div
-          className={
-            consecutive_failure_count.has(jobName) ? "failing-header" : ""
-          }
-        >
-          {summarize_job(jobName)}
-        </div>
-      </th>
-    ));
+    let s = "";
+    for (const j of visibleJobs) {
+      s += j + "\n";
+    }
+
+    // Collapse down groups of jobs based on a regex match to the name
+    const groupedVisibleJobsMap = {};
+    for (const jobName of visibleJobs) {
+      let group = findGroup(jobName);
+
+      if (!group || groupIsExpanded(group)) {
+        // Fake a group of size one
+        group = {
+          name: jobName,
+          jobNames: [jobName],
+        };
+      } else {
+        group.jobNames.push(jobName);
+      }
+      groupedVisibleJobsMap[group.name] = group;
+    }
+
+    // Go from the map of name -> group to a sorted list
+    let groupedVisibleJobs = [];
+    for (const groupName in groupedVisibleJobsMap) {
+      groupedVisibleJobs.push({
+        name: groupName,
+        group: groupedVisibleJobsMap[groupName],
+      });
+    }
+
+    for (const group of this.state.showGroups) {
+      // Keep in headers for expanded groups
+      groupedVisibleJobs.push({
+        name: group.name,
+        group: group,
+      });
+    }
+
+    // Sort by group name
+    groupedVisibleJobs.sort((a, b) => {
+      if (a.name < b.name) {
+        return -1;
+      }
+      if (a.name > b.name) {
+        return 1;
+      }
+      return 0;
+    });
+
+    // Now that jobs have been globally sorted, shuffle around the expanded groups
+    // so they show up next to their group header
+    for (const group of this.state.showGroups) {
+      let groupBaseIndex = groupedVisibleJobs.findIndex(
+        (job) => job.name == group.name
+      );
+      if (groupBaseIndex === null) {
+        console.error(`Unable to find group ${group.name}`);
+        continue;
+      }
+
+      console.log(`${group.name} is at ${groupBaseIndex}`);
+      for (const jobName of group.jobNames) {
+        let jobIndex = groupedVisibleJobs.findIndex(
+          (job) => job.name == jobName
+        );
+        if (jobIndex === null) {
+          console.error(`Unable to job ${jobName} in group ${group.name}`);
+          continue;
+        }
+        if (jobIndex < groupBaseIndex) {
+          array_move(groupedVisibleJobs, jobIndex, groupBaseIndex);
+        } else {
+          array_move(groupedVisibleJobs, jobIndex, groupBaseIndex + 1);
+        }
+      }
+    }
+
+    const toggleGroup = (group) => {
+      let showGroups = this.state.showGroups;
+
+      if (groupIsExpanded(group)) {
+        // Remove the group
+        showGroups.pop(
+          showGroups.findIndex((shownGroup) => shownGroup.name === group.name)
+        );
+      } else {
+        showGroups.push(group);
+      }
+      this.setState({ showGroups: showGroups });
+    };
+
+    const visibleJobsHeaders = [];
+    for (const data of groupedVisibleJobs) {
+      const jobName = data.name;
+      let header = (
+        <th className="rotate" key={jobName}>
+          <div
+            className={
+              consecutive_failure_count.has(jobName) ? "failing-header" : ""
+            }
+          >
+            {summarize_job(jobName)}
+          </div>
+        </th>
+      );
+
+      if (data.group.jobNames.length > 1) {
+        const group = data.group;
+        let icon = <BsFillCaretRightFill />;
+
+        if (groupIsExpanded(group)) {
+          icon = <BsFillCaretDownFill />;
+        }
+
+        let headerClass = "";
+        if (groupIsFailing(group)) {
+          headerClass = "failing-text";
+        }
+
+        header = (
+          <th className="rotate" key={jobName}>
+            <div
+              onClick={() => {
+                toggleGroup(group);
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              <span style={{ color: "#d0d0d0" }}>Group </span>
+              <span className={headerClass}>{group.name}</span> {icon}
+            </div>
+          </th>
+        );
+      }
+      visibleJobsHeaders.push(header);
+    }
+
+    function aggregateStatus(jobs) {
+      // The logic here follows these rules (in order):
+      // 1. If there are no jobs, return no status
+      // 2. Failed if any job is failed
+      // 3. Pending if any job is pending
+      // 4. Success if all jobs are success, skipped, or aborted
+      // 5. Otherwise pending
+
+      jobs = jobs.filter((x) => x !== undefined);
+      if (jobs.length == 0) {
+        // No jobs in the group so don't show anything
+        return null;
+      }
+
+      for (const job of jobs) {
+        if (is_failure(job.status) || is_infra_failure(job.status)) {
+          return "failure";
+        }
+      }
+
+      for (const job of jobs) {
+        if (is_pending(job.status)) {
+          return "pending";
+        }
+      }
+
+      let allOk = true;
+      for (const job of jobs) {
+        if (
+          !(
+            is_success(job.status) ||
+            is_skipped(job.status) ||
+            is_aborted(job.status)
+          )
+        ) {
+          allOk = false;
+        }
+      }
+      if (allOk) {
+        return "success";
+      }
+
+      return "pending";
+    }
 
     const rows = builds.map((build) => {
       let found = false;
       const sb_map = build.sb_map;
 
-      const status_cols = visible_jobs.map((jobName) => {
-        const sb = sb_map.get(jobName);
+      const status_cols = groupedVisibleJobs.map((data) => {
         let cell = <Fragment />;
-        if (sb !== undefined) {
-          found = true;
-          cell = (
-            <a
-              href={sb.build_url}
-              className="icon"
-              target="_blank"
-              alt={jobName}
-            >
-              {result_icon(sb.status)}
-            </a>
+        let jobName = data.name;
+
+        if (data.group.jobNames.length > 1) {
+          // For groups, get the status of all the jobs in the group
+          jobName = `Group: ${data.group.name}`;
+          const jobs = data.group.jobNames.map((jobName) =>
+            sb_map.get(jobName)
           );
+          const status = aggregateStatus(jobs);
+          if (status) {
+            cell = (
+              <div
+                className="display-cell"
+                style={{
+                  fontWeight: "bold",
+                }}
+                onClick={() => {
+                  toggleGroup(data.group);
+                }}
+              >
+                {result_icon(status)}
+              </div>
+            );
+            found = true;
+          }
+        } else {
+          // Ungrouped job, show it directly
+          const sb = sb_map.get(jobName);
+          if (sb !== undefined) {
+            found = true;
+            cell = (
+              <div className="display-cell">
+                <a
+                  href={sb.build_url}
+                  className="icon"
+                  target="_blank"
+                  alt={jobName}
+                >
+                  {result_icon(sb.status)}
+                </a>
+              </div>
+            );
+          }
         }
 
         return (
@@ -366,15 +716,7 @@ export default class BuildHistoryDisplay extends Component {
             placement="rightTop"
             destroyTooltipOnHide={{ keepParent: false }}
           >
-            <td
-              key={jobName}
-              className="icon-cell"
-              style={{
-                textAlign: "right",
-                fontFamily: "sans-serif",
-                padding: 0,
-              }}
-            >
+            <td key={jobName} className="icon-cell">
               {cell}
             </td>
           </Tooltip>
@@ -421,6 +763,11 @@ export default class BuildHistoryDisplay extends Component {
         ? build.author.username
         : build.author.name;
 
+      // Cut off author at arbitrary length
+      if (author.length > 10) {
+        author = `${author.slice(0, 10)}...`;
+      }
+
       const desc = (
         <div key={build.id}>
           {drop_pr_number(build.message).split("\n")[0]}{" "}
@@ -456,7 +803,7 @@ export default class BuildHistoryDisplay extends Component {
           </td>
           {status_cols}
           <td className="right-cell">{author}</td>
-          <td className="right-cell">{desc}</td>
+          <td>{desc}</td>
         </tr>
       );
     });
@@ -485,7 +832,8 @@ export default class BuildHistoryDisplay extends Component {
               />
               <label htmlFor="show-notifications">
                 Show notifications on master failure
-                {Notification.permission === "denied" ? (
+                {this.state.showNotifications &&
+                Notification.permission === "denied" ? (
                   <Fragment>
                     {" "}
                     <strong>
@@ -511,6 +859,15 @@ export default class BuildHistoryDisplay extends Component {
             </li>
             <br />
             <li>
+              <input
+                type="checkbox"
+                name="group-jobs"
+                checked={this.state.groupJobs}
+                onChange={(e) => this.setState({ groupJobs: e.target.checked })}
+              />
+              <label htmlFor="group-jobs">Group related jobs</label>
+            </li>
+            <li>
               <form
                 onSubmit={(e) => {
                   e.preventDefault();
@@ -535,7 +892,7 @@ export default class BuildHistoryDisplay extends Component {
             <tr>
               <th className="left-cell">PR#</th>
               <th className="left-cell">Date</th>
-              {visible_jobs_head}
+              {visibleJobsHeaders}
               <th className="right-cell">User</th>
               <th className="right-cell">Description</th>
             </tr>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,6 +1158,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.1", "@babel/runtime@^7.11.1", "@babel/runtime@^7.12.5":
+  version "7.14.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
+  integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.13.8", "@babel/runtime@^7.14.0":
   version "7.14.0"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz"
@@ -2223,13 +2230,6 @@ acorn@^8.2.4:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.3.0.tgz"
   integrity sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw==
 
-add-dom-event-listener@1.x:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz"
-  integrity sha1-j67SxBAIchzxEdodMNmVuFvkK+0=
-  dependencies:
-    object-assign "4.x"
-
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/address/-/address-1.1.2.tgz"
@@ -2749,7 +2749,7 @@ babel-preset-react-app@^10.0.0:
     babel-plugin-macros "2.8.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
 
-babel-runtime@6.x, babel-runtime@^6.26.0:
+babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -3289,7 +3289,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.6, classnames@^2.3.1:
+classnames@2.x, classnames@^2.2.1, classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -3433,22 +3433,10 @@ commondir@^1.0.1:
   resolved "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-component-classes@^1.2.5:
-  version "1.2.6"
-  resolved "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz"
-  integrity sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=
-  dependencies:
-    component-indexof "0.0.3"
-
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
-component-indexof@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz"
-  integrity sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=
 
 compose-function@3.0.3:
   version "3.0.3"
@@ -3695,14 +3683,6 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
-
-css-animation@^1.3.2:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/css-animation/-/css-animation-1.4.1.tgz"
-  integrity sha1-W4gTEl3g+7uwu+G0cq6EIhRpt6g=
-  dependencies:
-    babel-runtime "6.x"
-    component-classes "^1.2.5"
 
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
@@ -7252,11 +7232,6 @@ lodash-es@^4.17.20:
   resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
-lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
@@ -7271,25 +7246,6 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
-
-lodash.isarguments@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
-  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
-
-lodash.isarray@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-  integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
-
-lodash.keys@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-  integrity sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=
-  dependencies:
-    lodash._getnative "^3.0.0"
-    lodash.isarguments "^3.0.0"
-    lodash.isarray "^3.0.0"
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -7882,7 +7838,7 @@ nwsapi@^2.2.0:
   resolved "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
-object-assign@4.x, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -9165,7 +9121,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9324,55 +9280,53 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc-align@^2.4.0:
-  version "2.4.3"
-  resolved "https://registry.npmjs.org/rc-align/-/rc-align-2.4.3.tgz"
-  integrity sha512-h5KgyB5IXYR7iKpYFcMr54cuQ2eozPCZ11kbXPG5+6CWvmyJ+c0R/yjndVndiNk2G3MKcTMbJNdDv5DIckLAxQ==
+rc-align@^4.0.0:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-4.0.9.tgz#46d8801c4a139ff6a65ad1674e8efceac98f85f2"
+  integrity sha512-myAM2R4qoB6LqBul0leaqY8gFaiECDJ3MtQDmzDo9xM9NRT/04TvWOYd2YHU9zvGzqk9QXF6S9/MifzSKDZeMw==
   dependencies:
-    babel-runtime "^6.26.0"
+    "@babel/runtime" "^7.10.1"
+    classnames "2.x"
     dom-align "^1.7.0"
-    prop-types "^15.5.8"
-    rc-util "^4.0.4"
+    rc-util "^5.3.0"
+    resize-observer-polyfill "^1.5.1"
 
-rc-animate@2.x:
+rc-motion@^2.0.0:
   version "2.4.4"
-  resolved "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.4.tgz"
-  integrity sha512-DjJLTUQj7XKKcuS8cczN0uOLfuSmgrVXFGieP1SZc87xUUTFGh8B/KjNmEtlfvxkSrSuVfb2rrEPER4SqKUtEA==
+  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.4.4.tgz#e995d5fa24fc93065c24f714857cf2677d655bb0"
+  integrity sha512-ms7n1+/TZQBS0Ydd2Q5P4+wJTSOrhIrwNxLXCZpR7Fa3/oac7Yi803HDALc2hLAKaCTQtw9LmQeB58zcwOsqlQ==
   dependencies:
-    babel-runtime "6.x"
-    css-animation "^1.3.2"
-    prop-types "15.x"
+    "@babel/runtime" "^7.11.1"
+    classnames "^2.2.1"
+    rc-util "^5.2.1"
 
-rc-tooltip@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.7.2.tgz"
-  integrity sha512-vsF29ohlfgr7lEP12aJ5j4U/4hzqSBYjWQo8I09re+q95v1o4nDjH1q/B3qFkf9aml2FbgdkJw9KYz/zXUgApA==
+rc-tooltip@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-5.1.1.tgz#94178ed162d0252bc4993b725f5dc2ac0fccf154"
+  integrity sha512-alt8eGMJulio6+4/uDm7nvV+rJq9bsfxFDCI0ljPdbuoygUscbsMYb6EQgwib/uqsXQUvzk+S7A59uYHmEgmDA==
   dependencies:
-    babel-runtime "6.x"
-    prop-types "^15.5.8"
-    rc-trigger "^2.2.2"
+    "@babel/runtime" "^7.11.2"
+    rc-trigger "^5.0.0"
 
-rc-trigger@^2.2.2:
-  version "2.5.4"
-  resolved "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.5.4.tgz"
-  integrity sha512-clgXOdazDW2qg4vTZSAExpvOuojPNuMoamG+SxAm5Ih+rpVcrtEiDlDZWY4yUHyfEWJZBzgbrr4np/z2FK6RfA==
+rc-trigger@^5.0.0:
+  version "5.2.9"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-5.2.9.tgz#795a787d2b038347dcde27b89a4a5cec8fc40f3e"
+  integrity sha512-0Bxsh2Xe+etejMn73am+jZBcOpsueAZiEKLiGoDfA0fvm/JHLNOiiww3zJ0qgyPOTmbYxhsxFcGOZu+VcbaZhQ==
   dependencies:
-    babel-runtime "6.x"
+    "@babel/runtime" "^7.11.2"
     classnames "^2.2.6"
-    prop-types "15.x"
-    rc-align "^2.4.0"
-    rc-animate "2.x"
-    rc-util "^4.4.0"
+    rc-align "^4.0.0"
+    rc-motion "^2.0.0"
+    rc-util "^5.5.0"
 
-rc-util@^4.0.4, rc-util@^4.4.0:
-  version "4.5.1"
-  resolved "https://registry.npmjs.org/rc-util/-/rc-util-4.5.1.tgz"
-  integrity sha512-PdCmHyBBodZdw6Oaikt0l+/R79IcRXpYkTrqD/Rbl4ZdoOi61t5TtEe40Q+A7rkWG5U1xjcN+h8j9H6GdtnICw==
+rc-util@^5.2.1, rc-util@^5.3.0, rc-util@^5.5.0:
+  version "5.13.2"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.13.2.tgz#a8a0bb77743351841ba8bed6393e03b8d2f685c8"
+  integrity sha512-eYc71XXGlp96RMzg01Mhq/T3BL6OOVTDSS0urFEuvpi+e7slhJRhaHGCKy2hqJm18m9ff7VoRoptplKu60dYog==
   dependencies:
-    add-dom-event-listener "1.x"
-    babel-runtime "6.x"
-    prop-types "^15.5.10"
-    shallowequal "^0.2.2"
+    "@babel/runtime" "^7.12.5"
+    react-is "^16.12.0"
+    shallowequal "^1.1.0"
 
 react-app-polyfill@^2.0.0:
   version "2.0.0"
@@ -9459,9 +9413,9 @@ react-icons@^4.2.0:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"
   integrity sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==
 
-react-is@^16.3.2, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.3.2, react-is@^16.8.1:
   version "16.13.1"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^17.0.1:
@@ -9847,6 +9801,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -10279,12 +10238,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shallowequal@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz"
-  integrity sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=
-  dependencies:
-    lodash.keys "^3.1.2"
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #83
* #82
* **#81**

This adds a bunch of groups of jobs (based on a regex that is matched against the name) that makes it so the HUD is compressed enough to show up without any horizontal scrolling on a reasonable screen. When you expand a job the jobs are out of sorted order since they are inserted right after the group's name. There is also another option to disable the grouping altogether. See the deploy preview for usage.

The actual groups themselves are also totally open for debate / bikeshedding. A follow up diff will merge in the binary builds and fix #68.

This also updates `rc-tooltip` since we were already using an API that wasn't present in the old version