### PR TITLE
Remove separation of binary builds / master

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,8 +40,6 @@ const App = () => (
                 <Link to={`/build2/${e}-${trigger}`}>
                   {e}-{trigger}
                 </Link>
-                &nbsp; (
-                <Link to={`/build2/${e}-${trigger}?mode=nightly`}>binary</Link>)
               </li>
             ))}
           </Fragment>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#83**
* #82
* #81

This puts binary builds on the same page as regular jobs, see #68 for some more context. This also removes the option to show service jobs since they are all shoved into a group now.

Netlify doesn't like ghstack, so check https://github.com/pytorch/pytorch-ci-hud/pull/84#issuecomment-888094865 for a preview of the entire stack.

![image](https://user-images.githubusercontent.com/9407960/127396562-15f2bed0-3158-4c7a-a155-80a37b121177.png)
