### PR TITLE
Show SEVs on the HUD

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -282,3 +282,11 @@ body {
 .hideRadio label {
   font-size: 0.75em;
 }
+
+.sevbox {
+  border: 1px solid red;
+  border-radius: 5px;
+  background-color: #ffe1e1;
+  padding: 10px;
+  margin-bottom: 10px;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import PrDisplay from "./PrDisplay.js";
 import JobCorrelationHeatmap from "./JobCorrelationHeatmap.js";
 import GitHubActionsDisplay from "./GitHubActionsDisplay.js";
 import AuthorizeGitHub from "./AuthorizeGitHub.js";
+import SevReporter from "./SevReporter.js";
 import {
   BrowserRouter as Router,
   Route,
@@ -93,6 +94,7 @@ const App = () => (
           </li>
         </Fragment>
       </ul>
+      <SevReporter />
       <Switch>
         <Route path="/build" component={BuildRoute} />
         <Route path="/build1" component={Build1Route} />

--- a/src/PrDisplay.js
+++ b/src/PrDisplay.js
@@ -992,7 +992,13 @@ export default class PrDisplay extends Component {
         {loading}
 
         {this.renderDocPreviewButton()}
-        <div>{displayRuns}</div>
+        <div>
+          {displayRuns.length == 0 ? (
+            <p style={{ fontWeight: "bold" }}>No jobs found</p>
+          ) : (
+            displayRuns
+          )}
+        </div>
       </div>
     );
   }

--- a/src/SevReporter.js
+++ b/src/SevReporter.js
@@ -1,0 +1,78 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import { Component } from "react";
+import AuthorizeGitHub from "./AuthorizeGitHub.js";
+
+import { github } from "./utils.js";
+
+function getIssuesQuery() {
+  return `
+      {
+        search(type:ISSUE,first:100,query:"is:open is:issue label:\\\"ci: sev\\\"") {
+          nodes {
+            ... on Issue {
+              number
+              title
+              body
+              url
+            }
+          }
+        }
+      }
+    `;
+}
+
+export default class PrDisplay extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      sevs: [],
+    };
+  }
+
+  componentDidMount() {
+    this.update();
+  }
+
+  async update() {
+    if (!localStorage.getItem("gh_pat")) {
+      // Not logged in, can't search GitHub
+      // TODO: Show login option
+      console.log("not logged in, can't fetch sevs");
+      return;
+    }
+    const response = await github.graphql_raw(getIssuesQuery());
+    if (response.errors) {
+      console.error("failed to fetch sevs");
+      console.error(response);
+      return;
+    }
+    this.state.sevs = response.data.search.nodes;
+
+    this.setState(this.state);
+  }
+
+  renderSev(issue) {
+    return (
+      <div className="sevbox">
+        <a href="https://github.com/pytorch/pytorch/wiki/%5BWIP%5D-What-is-a-SEV">
+          SEV:
+        </a>{" "}
+        {issue.title} (<a href={issue.url}>#{issue.number}</a>)
+      </div>
+    );
+  }
+
+  render() {
+    const existingSevs = this.state.sevs;
+    const renderedSevs = [];
+    for (const [index, sev] of existingSevs.entries()) {
+      renderedSevs.push(<div key={`sev-${index}`}>{this.renderSev(sev)}</div>);
+    }
+
+    return <div>{renderedSevs}</div>;
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,7 +71,7 @@ export async function asyncAll(functions) {
   return await Promise.all(invoked);
 }
 
-async function github_graphql(query) {
+async function github_graphql_raw(query) {
   // Query the GitHub GraphQL API
   const pat = localStorage.getItem("gh_pat");
   const result = await fetch("https://api.github.com/graphql", {
@@ -84,7 +84,11 @@ async function github_graphql(query) {
   if (result.status !== 200) {
     throw `Error fetching data from GitHub: ${await result.text()}`;
   }
-  return (await result.json()).data;
+  return await result.json();
+}
+
+async function github_graphql(query) {
+  return (await github_graphql_raw(query)).data;
 }
 
 export async function github_json(url) {
@@ -113,6 +117,7 @@ export async function github_raw(url) {
 
 export let github = {
   graphql: github_graphql,
+  graphql_raw: github_graphql_raw,
   json: github_json,
   raw: github_raw,
 };


### PR DESCRIPTION
This queries GitHub for open SEVs (i.e. issues with the `ci: sev` label). If the user is not already logged in this does nothing.

![image](https://user-images.githubusercontent.com/9407960/131169837-b1885546-6a18-4af2-84cb-37a066a3b15e.png)
