### PR TITLE
Use monaco editor (VSCode) instead of react-lazylog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+yarn.lock linguist-generated=true
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@monaco-editor/react": "^4.2.2",
     "@toast-ui/chart": "^4.3.4",
     "axios": "^0.21.1",
     "bootstrap": "^4.6.0",
@@ -16,7 +17,6 @@
     "react-bootstrap": "^1.6.1",
     "react-dom": "^16.2.0",
     "react-icons": "^4.2.0",
-    "react-lazylog": "^4.5.3",
     "react-router-dom": "^4.2.2",
     "react-scripts": "^4.0.3"
   },

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -213,34 +213,36 @@ export default class BuildHistoryDisplay extends Component {
     });
 
     // Step 3: Add jenkins jobs
-    jenkins_data.builds.forEach((topBuild) => {
-      if (topBuild.changeSet.items.length !== 1) {
-        return;
-      }
-      const buildCommitId = topBuild.changeSet.items[0].commitId;
-      if (!(buildCommitId in commitIdxMap)) {
-        return;
-      }
-      const buildIdx = commitIdxMap[buildCommitId];
-      function go(subBuild) {
-        if (
-          subBuild.build &&
-          subBuild.build._class ===
-            "com.tikal.jenkins.plugins.multijob.MultiJobBuild"
-        ) {
-          subBuild.build.subBuilds.forEach(go);
-        } else {
-          builds[buildIdx].sb_map.set(
-            getJenkinsJobName(subBuild),
-            Object.fromEntries([
-              ["status", subBuild.result],
-              ["build_url", jenkins.link(subBuild.url + "/console")],
-            ])
-          );
+    if (jenkins_data) {
+      jenkins_data.builds.forEach((topBuild) => {
+        if (topBuild.changeSet.items.length !== 1) {
+          return;
         }
-      }
-      topBuild.subBuilds.forEach(go);
-    });
+        const buildCommitId = topBuild.changeSet.items[0].commitId;
+        if (!(buildCommitId in commitIdxMap)) {
+          return;
+        }
+        const buildIdx = commitIdxMap[buildCommitId];
+        function go(subBuild) {
+          if (
+            subBuild.build &&
+            subBuild.build._class ===
+              "com.tikal.jenkins.plugins.multijob.MultiJobBuild"
+          ) {
+            subBuild.build.subBuilds.forEach(go);
+          } else {
+            builds[buildIdx].sb_map.set(
+              getJenkinsJobName(subBuild),
+              Object.fromEntries([
+                ["status", subBuild.result],
+                ["build_url", jenkins.link(subBuild.url + "/console")],
+              ])
+            );
+          }
+        }
+        topBuild.subBuilds.forEach(go);
+      });
+    }
   }
   async update() {
     const currentTime = new Date();

--- a/src/PrDisplay.js
+++ b/src/PrDisplay.js
@@ -353,20 +353,20 @@ export default class PrDisplay extends Component {
               marginBottom: "20px",
             }}
           >
-          <Editor
-            height="80vh"
-            defaultLanguage="log"
-            defaultValue={check.log.text}
-            theme="vs-dark"
-            options={{
-              scrollBeyondLastLine: false,
-              lineNumbersMinChars: totalLines.toString().length + 1,
-            }}
-            onMount={(editor, monaco) => {
-              editor.revealLine(totalLines);
-            }}
-            loading={<p>Loading viewer...</p>}
-          />
+            <Editor
+              height="80vh"
+              defaultLanguage="log"
+              defaultValue={check.log.text}
+              theme="vs-dark"
+              options={{
+                scrollBeyondLastLine: false,
+                lineNumbersMinChars: totalLines.toString().length + 1,
+              }}
+              onMount={(editor, monaco) => {
+                editor.revealLine(totalLines);
+              }}
+              loading={<p>Loading viewer...</p>}
+            />
           </div>
         );
       } else {

--- a/src/PrDisplay.js
+++ b/src/PrDisplay.js
@@ -7,6 +7,8 @@ import React, { Component } from "react";
 import Card from "react-bootstrap/Card";
 import AuthorizeGitHub from "./AuthorizeGitHub.js";
 import TestReportRenderer from "./pr/TestReportRenderer.js";
+import Editor from "@monaco-editor/react";
+
 import {
   BsFillCaretRightFill,
   BsCaretDownFill,
@@ -16,7 +18,6 @@ import {
   GoCheck,
   GoX,
 } from "react-icons/all";
-import { LazyLog } from "react-lazylog";
 
 import { parseXml, formatBytes, asyncAll, s3, github } from "./utils.js";
 
@@ -345,17 +346,27 @@ export default class PrDisplay extends Component {
       isShowing = true;
       if (check.log.text) {
         const totalLines = (check.log.text.match(/\n/g) || "").length + 1;
-
         log = (
-          <div style={{ height: `${Math.min(totalLines + 4, 30)}em` }}>
-            <LazyLog
-              extraLines={1}
-              enableSearch
-              caseInsensitive
-              selectableLines
-              scrollToLine={totalLines}
-              text={check.log.text}
-            />
+          <div
+            style={{
+              height: `${Math.min(totalLines + 4, 30)}em`,
+              marginBottom: "20px",
+            }}
+          >
+          <Editor
+            height="80vh"
+            defaultLanguage="log"
+            defaultValue={check.log.text}
+            theme="vs-dark"
+            options={{
+              scrollBeyondLastLine: false,
+              lineNumbersMinChars: totalLines.toString().length + 1,
+            }}
+            onMount={(editor, monaco) => {
+              editor.revealLine(totalLines);
+            }}
+            loading={<p>Loading viewer...</p>}
+          />
           </div>
         );
       } else {

--- a/src/pr/TestReportRenderer.js
+++ b/src/pr/TestReportRenderer.js
@@ -5,7 +5,6 @@
 
 import React, { Component } from "react";
 import Card from "react-bootstrap/Card";
-import { LazyLog } from "react-lazylog";
 import { highlightElement } from "highlight.js";
 import { strFromU8, unzipSync } from "fflate";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,12 +1460,20 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@mattiasbuelens/web-streams-polyfill@^0.2.0":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@mattiasbuelens/web-streams-polyfill/-/web-streams-polyfill-0.2.1.tgz#d7c4aa94f98084ec0787be084d47167d62ea5f67"
-  integrity sha512-oKuFCQFa3W7Hj7zKn0+4ypI8JFm4ZKIoncwAC6wd5WwFW2sL7O1hpPoJdSWpynQ4DJ4lQ6MvFoVDmCLilonDFg==
+"@monaco-editor/loader@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.1.1.tgz#37db648c81a86946d0febd391de00df9c28a0a3d"
+  integrity sha512-mkT4r4xDjIyOG9o9M6rJDSzEIeonwF80sYErxEvAAL4LncFVdcbNli8Qv6NDqF6nyv6sunuKkDzo4iFjxPL+uQ==
   dependencies:
-    "@types/whatwg-streams" "^0.0.7"
+    state-local "^1.0.6"
+
+"@monaco-editor/react@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.2.2.tgz#636e5b8eb9519ef62f475f9a4a50f62ee0c493a8"
+  integrity sha512-yDDct+f/mZ946tJEXudvmMC8zXDygkELNujpJGjqJ0gS3WePZmS/IwBBsuJ8JyKQQC3Dy/+Ivg1sSpW+UvCv9g==
+  dependencies:
+    "@monaco-editor/loader" "^1.1.1"
+    prop-types "^15.7.2"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -1904,11 +1912,6 @@
     "@types/webpack-sources" "*"
     anymatch "^3.0.0"
     source-map "^0.6.0"
-
-"@types/whatwg-streams@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@types/whatwg-streams/-/whatwg-streams-0.0.7.tgz#28bfe73dc850562296367249c4b32a50db81e9d3"
-  integrity sha512-6sDiSEP6DWcY2ZolsJ2s39ZmsoGQ7KVwBDI3sESQsEm9P2dHTcqnDIHRZFRNtLCzWp7hCFGqYbw5GyfpQnJ01A==
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -3324,11 +3327,6 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
-clsx@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
-  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
@@ -4382,7 +4380,7 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^5.0.1, dom-helpers@^5.1.3, dom-helpers@^5.2.0, dom-helpers@^5.2.1:
+dom-helpers@^5.0.1, dom-helpers@^5.2.0, dom-helpers@^5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -5154,11 +5152,6 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
-
-fetch-readablestream@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-readablestream/-/fetch-readablestream-0.2.0.tgz#eaa6d1a76b12de2d4731a343393c6ccdcfe2c795"
-  integrity sha512-qu4mXWf4wus4idBIN/kVH+XSer8IZ9CwHP+Pd7DL7TuKNC1hP7ykon4kkBjwJF3EMX2WsFp4hH7gU7CyL7ucXw==
 
 fflate@^0.7.1:
   version "0.7.1"
@@ -5975,11 +5968,6 @@ immer@8.0.1:
   version "8.0.1"
   resolved "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
-
-immutable@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
-  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -7282,7 +7270,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.0:
+"lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7571,11 +7559,6 @@ mississippi@^3.0.0:
     pumpify "^1.3.3"
     stream-each "^1.1.0"
     through2 "^2.0.0"
-
-mitt@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.2.0.tgz#cb24e6569c806e31bd4e3995787fe38a04fdf90d"
-  integrity sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -9423,21 +9406,6 @@ react-is@^17.0.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-lazylog@^4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/react-lazylog/-/react-lazylog-4.5.3.tgz#289e24995b5599e75943556ac63f5e2c04d0001e"
-  integrity sha512-lyov32A/4BqihgXgtNXTHCajXSXkYHPlIEmV8RbYjHIMxCFSnmtdg4kDCI3vATz7dURtiFTvrw5yonHnrS+NNg==
-  dependencies:
-    "@mattiasbuelens/web-streams-polyfill" "^0.2.0"
-    fetch-readablestream "^0.2.0"
-    immutable "^3.8.2"
-    mitt "^1.1.2"
-    prop-types "^15.6.1"
-    react-string-replace "^0.4.1"
-    react-virtualized "^9.21.0"
-    text-encoding-utf-8 "^1.0.1"
-    whatwg-fetch "^2.0.4"
-
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz"
@@ -9553,13 +9521,6 @@ react-scripts@^4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react-string-replace@^0.4.1:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/react-string-replace/-/react-string-replace-0.4.4.tgz#24006fbe0db573d5be583133df38b1a735cb4225"
-  integrity sha512-FAMkhxmDpCsGTwTZg7p/2v+/GTmxAp73so3fbSvlAcBBX36ujiGRNEaM/1u+jiYQrArhns+7eE92g2pi5E5FUA==
-  dependencies:
-    lodash "^4.17.4"
-
 react-transition-group@^4.4.1:
   version "4.4.2"
   resolved "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz"
@@ -9569,18 +9530,6 @@ react-transition-group@^4.4.1:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-virtualized@^9.21.0:
-  version "9.22.3"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
-  integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
-  dependencies:
-    "@babel/runtime" "^7.7.2"
-    clsx "^1.0.4"
-    dom-helpers "^5.1.3"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
-    react-lifecycles-compat "^3.0.4"
 
 react@^16.10.0:
   version "16.14.0"
@@ -10521,6 +10470,11 @@ stackframe@^1.1.1:
   resolved "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz"
   integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
+state-local@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
+  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz"
@@ -10903,11 +10857,6 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
-
-text-encoding-utf-8@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz#585b62197b0ae437e3c7b5d0af27ac1021e10d13"
-  integrity sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==
 
 text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
@@ -11578,11 +11527,6 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
-  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
 whatwg-fetch@^3.4.1:
   version "3.6.2"


### PR DESCRIPTION
react-lazylog is an abandoned mozilla project (https://github.com/mozilla-frontend-infra/react-lazylog) with some limitations pointed out by @suo. This integrates a real text editor which should make browsing the logs on the PR page more familiar and powerful.

https://deploy-preview-109--pytorch-ci-hud.netlify.app/commit/f767cf668395baf29ca7c9f1fa80f0abed8c53c7

![image](https://user-images.githubusercontent.com/9407960/132440120-c9ab44d0-75c2-4678-9ac5-093656a21c20.png)
