### PR TITLE
Delete "Does not show Jenkins builds"

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -32,7 +32,7 @@ const App = () => (
         </h1>
       </header>
       <ul className="menu">
-        <li>New-style (Does not show Jenkins builds):</li>
+        <li>New-style:</li>
         {["pytorch"].map((e) => (
           <Fragment key={e}>
             {["master", "nightly", "release/1.9"].map((trigger) => (


### PR DESCRIPTION
As of https://github.com/pytorch/pytorch-ci-hud/commit/8c8911d7fe4c20888cf3407fdf06438f8399be45 Jenkins builds are displayed in new-style HUD
