### PR TITLE
Hide "generate-test-matrix" jobs from HUD

### DIFF
--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -355,11 +355,13 @@ export default class BuildHistoryDisplay extends Component {
     const isDockerJob = name.startsWith("ci/circleci: docker");
     const isGCJob = name.startsWith("ci/circleci: ecr_gc");
     const isCIFlowShouldRunJob = name.endsWith("ciflow_should_run");
+    const isGenerateTestMatrixJob = name.endsWith("generate-test-matrix");
     return !(
       isDockerJob ||
       name === "welcome" ||
       isGCJob ||
-      isCIFlowShouldRunJob
+      isCIFlowShouldRunJob ||
+      isGenerateTestMatrixJob
     );
   }
 


### PR DESCRIPTION
They never suppose to fail and therefore just waste screen space
