### PR TITLE
TestRender: Do not add empty testsuites

### DIFF
--- a/src/pr/TestReportRenderer.js
+++ b/src/pr/TestReportRenderer.js
@@ -200,7 +200,7 @@ export default class TestReportRenderer extends Component {
           for (const suite of data.testsuites.testsuite) {
             suites.push(suite);
           }
-        } else {
+        } else if (data.testsuites.testsuite) {
           suites.push(data.testsuites.testsuite);
         }
       } else {


### PR DESCRIPTION
Fix `TypeError: Cannot read properties of undefined (reading 'errors')`
while parsing following trivial testsuite:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="0" failures="0" disabled="0" errors="0" time="0" timestamp="2021-09-14T03:35:19.039" name="AllTests">
</testsuites>
```

For example, check out `win-vs2019-cpu-py3` results of https://hud.pytorch.org/commit/ab5e1c69a7e77f79df64b6ad3b04cff72e09807b
