### PR TITLE
Add negative filtering for CI logs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -270,3 +270,15 @@ body {
 .center {
   text-align: center;
 }
+
+.hideRadio input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  -o-appearance: none;
+  appearance: none;
+}
+
+.hideRadio label {
+  font-size: 0.75em;
+}


### PR DESCRIPTION
Lots of the lines in our CI log output are not very informative, so this adds a mechanism to strip them out by default.

![image](https://user-images.githubusercontent.com/9407960/133526392-e9965dd0-fe28-416f-9f41-299bacb808b6.png)
