### PR TITLE
Add custom `log` lanauge to monaco

### DIFF
--- a/src/PrDisplay.js
+++ b/src/PrDisplay.js
@@ -378,6 +378,7 @@ export default class PrDisplay extends Component {
       /Z untagged: sha256/,
       /Z untagged: .*amazonaws/,
       /Z \s*adding: /,
+      /Z \s*creating: /,
       /Z \s*inflating: /,
       /Z \s*extracting: /,
       /Z adding /,
@@ -417,6 +418,95 @@ export default class PrDisplay extends Component {
       }
     }
     return newLog;
+  }
+
+  registerLogLanguage(monaco, groupRanges) {
+    // Register a new language
+    monaco.languages.register({ id: "logText" });
+
+    // Register a tokens provider for the language
+    monaco.languages.setMonarchTokensProvider("logText", {
+      tokenizer: {
+        root: [
+          [/\[30;1m.*?\[0m/, "black"],
+          [/\[31;1m.*?\[0m/, "red"],
+          [/\[32;1m.*?\[0m/, "green"],
+          [/\[33;1m.*?\[0m/, "yellow"],
+          [/\[34;1m.*?\[0m/, "blue"],
+          [/\[35;1m.*?\[0m/, "magenta"],
+          [/\[36;1m.*?\[0m/, "cyan"],
+          [/\[37;1m.*?\[0m/, "white"],
+
+          [/\[30m.*?\[0m/, "black"],
+          [/\[31m.*?\[0m/, "red"],
+          [/\[32m.*?\[0m/, "green"],
+          [/\[33m.*?\[0m/, "yellow"],
+          [/\[34m.*?\[0m/, "blue"],
+          [/\[35m.*?\[0m/, "magenta"],
+          [/\[36m.*?\[0m/, "cyan"],
+          [/\[37m.*?\[0m/, "white"],
+
+          [/\[0;1;30m.*?\[0m/, "black"],
+          [/\[0;1;31m.*?\[0m/, "red"],
+          [/\[0;1;32m.*?\[0m/, "green"],
+          [/\[0;1;33m.*?\[0m/, "yellow"],
+          [/\[0;1;34m.*?\[0m/, "blue"],
+          [/\[0;1;35m.*?\[0m/, "magenta"],
+          [/\[0;1;36m.*?\[0m/, "cyan"],
+          [/\[0;1;37m.*?\[0m/, "white"],
+
+          [/\[1m.*?\[0m/, "cyan"],
+          [/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{7}Z/, "hidden"],
+        ],
+      },
+    });
+
+    // Define a new theme that contains only rules that match this language
+    monaco.editor.defineTheme("logTheme", {
+      base: "vs-dark",
+      inherit: true,
+      rules: [
+        { token: "black", foreground: "000000", fontStyle: "bold" },
+        { token: "red", foreground: "af0000", fontStyle: "bold" },
+        { token: "green", foreground: "87d700", fontStyle: "bold" },
+        { token: "yellow", foreground: "d7d700", fontStyle: "bold" },
+        { token: "blue", foreground: "5fd7ff", fontStyle: "bold" },
+        { token: "magenta", foreground: "8700af", fontStyle: "bold" },
+        { token: "cyan", foreground: "00af87", fontStyle: "bold" },
+        { token: "white", foreground: "ffffff", fontStyle: "bold" },
+        { token: "hidden", foreground: "5f5f5f" },
+      ],
+    });
+
+    monaco.languages.registerFoldingRangeProvider("logText", {
+      provideFoldingRanges: function (model, context, token) {
+        return groupRanges;
+      },
+    });
+  }
+
+  getGroupRanges(monaco, text) {
+    const lines = text.split("\n");
+    const starts = [];
+    const ends = [];
+    let lineNumber = 0;
+    for (const line of lines) {
+      if (line.includes("##[group]")) {
+        starts.push(lineNumber);
+      } else if (line.includes("##[endgroup]")) {
+        ends.push(lineNumber);
+      }
+      lineNumber += 1;
+    }
+    let ranges = [];
+    for (let i = 0; i < Math.min(starts.length, ends.length); i++) {
+      ranges.push({
+        start: starts[i] + 1,
+        end: ends[i] + 1,
+        kind: monaco.languages.FoldingRangeKind.Imports,
+      });
+    }
+    return ranges;
   }
 
   renderLogViewer(check) {
@@ -472,16 +562,24 @@ export default class PrDisplay extends Component {
             </div>
             <Editor
               height="80vh"
-              defaultLanguage="log"
+              defaultLanguage="logText"
               defaultValue={logText}
-              theme="vs-dark"
+              theme="logTheme"
+              beforeMount={(monaco) => {
+                const groupRanges = this.getGroupRanges(monaco, logText);
+                this.registerLogLanguage(monaco, groupRanges);
+              }}
               options={{
                 scrollBeyondLastLine: false,
                 lineNumbersMinChars: totalLines.toString().length + 1,
+                folding: true,
               }}
               onMount={(editor, monaco) => {
                 check.log.existingEditor = editor;
-                editor.revealLine(totalLines);
+                let foldAction = editor.getAction("editor.foldAll");
+                foldAction.run().then(() => {
+                  editor.revealLine(totalLines);
+                });
               }}
               loading={<p>Loading viewer...</p>}
             />


### PR DESCRIPTION
This makes the editor aware of our log format for some basic highlighting (de-emphasize timestamps, enable ansi colors)  and adds standard vscode folding to the `##[group]` and `##[endgroup]` sections. Sadly these are not auto-added to each step, so we maybe should consider inserting our own around larger steps.

![image](https://user-images.githubusercontent.com/9407960/133708064-7e33fbbd-93bd-463b-b446-4365c008cc5c.png)
