### PR TITLE
Add `check_suite_focus=true` to GHA run jobs

### DIFF
--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -782,7 +782,9 @@ export default class BuildHistoryDisplay extends Component {
 
     function decoratedBuildUrl(url) {
       // Add check_suite_focus=true to GHA checkruns
-      const ghaRegex = new RegExp("^https://github.com/pytorch/pytorch/runs/\\d+$");
+      const ghaRegex = new RegExp(
+        "^https://github.com/pytorch/pytorch/runs/\\d+$"
+      );
       if (url.match(ghaRegex)) {
         return url + "?check_suite_focus=true";
       }

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -780,6 +780,15 @@ export default class BuildHistoryDisplay extends Component {
       return "pending";
     }
 
+    function decoratedBuildUrl(url) {
+      // Add check_suite_focus=true to GHA checkruns
+      const ghaRegex = new RegExp("^https://github.com/pytorch/pytorch/runs/\\d+$");
+      if (url.match(ghaRegex)) {
+        return url + "?check_suite_focus=true";
+      }
+      return url;
+    }
+
     const rows = builds.map((build) => {
       let found = false;
       const sb_map = build.sb_map;
@@ -822,7 +831,7 @@ export default class BuildHistoryDisplay extends Component {
             cell = (
               <div className="display-cell">
                 <a
-                  href={sb.build_url}
+                  href={decoratedBuildUrl(sb.build_url)}
                   className="icon"
                   target="_blank"
                   alt={jobName}


### PR DESCRIPTION
Makes it much easier to figure out what workflow particular run belongs to.
Before the change https://github.com/pytorch/pytorch/runs/3758882785 looked as follows:
![image](https://user-images.githubusercontent.com/2453524/135514939-c3552160-0b1e-41bb-82b4-4799491565f0.png)
After the change link changes to https://github.com/pytorch/pytorch/runs/3758882785?check_suite_focus=true
![image](https://user-images.githubusercontent.com/2453524/135515216-89c3a1b5-855a-4c4b-b62e-3aa9cf12ee40.png)

Preview link: https://deploy-preview-140--pytorch-ci-hud.netlify.app/