### PR TITLE
Add redirects for GitHub URLs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -98,7 +98,25 @@ const App = () => (
       <Switch>
         <Route path="/build" component={BuildRoute} />
         <Route path="/build1" component={Build1Route} />
-        <Route path="/pr" component={PrRoute} />
+        <Route
+          path="/pytorch/pytorch/pull/:segment"
+          render={(props) => {
+            return <Redirect to={`/pr/${props.match.params.segment}`} />;
+          }}
+        ></Route>
+        <Route
+          path="/pytorch/pytorch/pull/*/commits/:segment"
+          render={(props) => {
+            return <Redirect to={`/commit/${props.match.params.segment}`} />;
+          }}
+        ></Route>
+        <Route
+          path="/pytorch/pytorch/commit/:segment"
+          render={(props) => {
+            return <Redirect to={`/commit/${props.match.params.segment}`} />;
+          }}
+        ></Route>
+        <Route path="/pr/:segment" component={PrRoute} />
         <Route path="/commit/:segment" component={CommitPage} />
         <Route path="/build2" component={Build2Route} />
         <Route path="/torchbench-v0-nightly" component={TorchBenchRoute} />
@@ -205,13 +223,6 @@ const CommitPage = ({ match }) => {
 const RouteNotFound = ({ match }) => {
   return <p>Route not found: {match.url}</p>;
 };
-
-const CommitRoute = ({ match }) => (
-  <Fragment>
-    <Route exact path={match.url} component={CommitPage} />
-    <Route path={`${match.url}/:segment`} component={CommitRoute} />
-  </Fragment>
-);
 
 const BuildRoute = ({ match }) => (
   <Fragment>


### PR DESCRIPTION
This adds some redirects so that you can replace github.com with hud.pytorch.org and go to the relevant page on the HUD. This should make it easier to get to the HUD without hunting for the Dr. CI comment
