### PR TITLE
Use new status lambda

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -53,9 +53,31 @@ const App = () => (
               return <Redirect to={`/commit/${props.match.params.segment}`} />;
             }}
           ></Route>
+          <Route
+            path="/ci/:user/:repo/:branch+"
+            render={(props) => {
+              const query = new URLSearchParams(window.location.search);
+              const params = props.match.params;
+              return (
+                <GitHubStatusDisplay
+                  interval={60000}
+                  repo={params.repo}
+                  user={params.user}
+                  branch={params.branch}
+                  jobNameFilter={query.get("name_filter")}
+                />
+              );
+            }}
+          ></Route>
           <Route path="/pr/:segment" component={PrRoute} />
           <Route path="/commit/:segment" component={CommitPage} />
-          <Route path="/build2" component={Build2Route} />
+          <Route
+            path="/build2/:segment"
+            render={(props) => {
+              const branch = props.match.params.segment.replace("pytorch-", "");
+              return <Redirect to={`/ci/pytorch/pytorch/${branch}`} />;
+            }}
+          />
           <Route path="/build3" component={Build3Route} />
           <Route path="/torchbench-v0-nightly" component={TorchBenchRoute} />
           <Route path="/github_logout" component={LogoutGitHub} />

--- a/src/Links.js
+++ b/src/Links.js
@@ -91,13 +91,15 @@ export default class Links extends Component {
             <ul style={{ display: "inline" }} className="menu">
               {["pytorch"].map((e) => (
                 <Fragment key={e}>
-                  {["master", "nightly", "release/1.10"].map((trigger) => (
-                    <li key={`${e}-${trigger}`}>
-                      <Link to={`/build2/${e}-${trigger}`}>
-                        {e}-{trigger}
-                      </Link>
-                    </li>
-                  ))}
+                  {["master", "viable/strict", "nightly", "release/1.10"].map(
+                    (branch) => (
+                      <li key={`${branch}`}>
+                        <Link to={`/ci/pytorch/pytorch/${branch}`}>
+                          {branch}
+                        </Link>
+                      </li>
+                    )
+                  )}
                 </Fragment>
               ))}
               <li>

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -1,0 +1,23 @@
+import { groups as pytorch } from "./pytorch.js";
+import { groups as vision } from "./vision.js";
+
+const map = {
+  pytorch: pytorch,
+  vision: vision,
+};
+
+export default function getGroups(repo) {
+  const result = [];
+  if (!map[repo]) {
+    console.error(`Unknown group repo ${repo}`);
+    return [];
+  }
+
+  for (const group of map[repo]) {
+    let obj = {};
+    Object.assign(obj, group);
+    result.push(obj);
+  }
+
+  return result;
+}

--- a/src/groups/pytorch.js
+++ b/src/groups/pytorch.js
@@ -1,0 +1,107 @@
+export const groups = [
+  {
+    regex: /Lint/,
+    name: "Lint Jobs",
+  },
+  {
+    regex: /(\(periodic-pytorch)|(ci\/circleci: periodic_pytorch)|(^periodic-)/,
+    name: "Periodic Jobs",
+  },
+  {
+    regex: /(Linux CI \(pytorch-linux-)|(^linux-)/,
+    name: "Linux GitHub Actions",
+  },
+  {
+    regex:
+      /(Add annotations )|(Close stale pull requests)|(Label PRs & Issues)|(Triage )|(Update S3 HTML indices)|(codecov\/project)|(Facebook CLA Check)|(auto-label-rocm)/,
+    name: "Annotations and labeling",
+  },
+  {
+    regex:
+      /(ci\/circleci: docker-pytorch-)|(ci\/circleci: ecr_gc_job_)|(ci\/circleci: docker_for_ecr_gc_build_job)|(Garbage Collect ECR Images)/,
+    name: "Docker",
+  },
+  {
+    regex: /(Windows CI \(pytorch-)|(^win-)/,
+    name: "Windows GitHub Actions",
+  },
+  {
+    regex: / \/ calculate-docker-image/,
+    name: "GitHub calculate-docker-image",
+  },
+  {
+    regex: /ci\/circleci: pytorch_ios_/,
+    name: "ci/circleci: pytorch_ios",
+  },
+  {
+    regex:
+      /(ci\/circleci: pytorch_parallelnative_)|(ci\/circleci: pytorch_paralleltbb_)|(paralleltbb-linux-)|(parallelnative-linux-)/,
+    name: "Parallel",
+  },
+  {
+    regex:
+      /(ci\/circleci: pytorch_cpp_doc_build)|(ci\/circleci: pytorch_cpp_doc_test)|(pytorch_python_doc_build)|(pytorch_doc_test)/,
+    name: "Docs",
+  },
+  {
+    regex: /ci\/circleci: pytorch_linux_bionic_cuda10_2_cudnn7_py3_9_gcc7_/,
+    name: "ci/circleci: pytorch_linux_bionic_cuda10_2_cudnn7_py3_9_gcc7",
+  },
+  {
+    regex: /ci\/circleci: pytorch_linux_xenial_cuda10_2_cudnn7_py3_/,
+    name: "ci/circleci: pytorch_linux_xenial_cuda10_2_cudnn7_py3",
+  },
+  {
+    regex: /ci\/circleci: pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_/,
+    name: "ci/circleci: pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7",
+  },
+  {
+    regex:
+      /(ci\/circleci: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_)|(ci\/circleci: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-)/,
+    name: "ci/circleci: pytorch_linux_xenial_py3_clang5_android_ndk",
+  },
+  {
+    regex: /ci\/circleci: pytorch_linux_xenial_py3_6_gcc7_build/,
+    name: "ci/circleci: pytorch_linux_xenial_py3_clang5_asan_build",
+  },
+  {
+    regex: /ci\/circleci: pytorch_linux_xenial_py3_clang5_mobile_/,
+    name: "ci/circleci: pytorch_linux_xenial_py3_clang5_mobile",
+  },
+  {
+    regex: /ci\/circleci: pytorch_linux_xenial_py3_clang7_onnx_/,
+    name: "ci/circleci: pytorch_linux_xenial_py3_clang7_onnx",
+  },
+  {
+    regex: /ci\/circleci: pytorch_linux_xenial_py3_clang5_asan_/,
+    name: "ci/circleci: pytorch_linux_xenial_py3_clang5_asan",
+  },
+  {
+    regex: /ci\/circleci: pytorch_linux_xenial_py3_6_gcc7_/,
+    name: "ci/circleci: pytorch_linux_xenial_py3_6_gcc7",
+  },
+  {
+    regex: /ci\/circleci: pytorch_macos_10_13_py3_/,
+    name: "ci/circleci: pytorch_macos_10_13_py3",
+  },
+  {
+    regex: /ci\/circleci: pytorch_linux_xenial_py3_6_gcc5_4_/,
+    name: "ci/circleci: pytorch_linux_xenial_py3_6_gcc5_4",
+  },
+  {
+    regex: /ci\/circleci: binary_linux_/,
+    name: "ci/circleci: binary_linux",
+  },
+  {
+    regex: /ci\/circleci: binary_macos_/,
+    name: "ci/circleci: binary_macos",
+  },
+  {
+    regex: /ci\/circleci: binary_windows_/,
+    name: "ci/circleci: binary_windows",
+  },
+  {
+    regex: /(pytorch-linux-bionic-rocm)|(pytorch_linux_bionic_rocm)/,
+    name: "ROCm",
+  },
+];

--- a/src/groups/vision.js
+++ b/src/groups/vision.js
@@ -1,0 +1,18 @@
+export const groups = [
+  {
+    regex: /ci\/circleci: unittest/,
+    name: "CircleCI unittest",
+  },
+  {
+    regex: /ci\/circleci: binary_linux/,
+    name: "CircleCI binary_linux",
+  },
+  {
+    regex: /ci\/circleci: binary_macos/,
+    name: "CircleCI binary_macos",
+  },
+  {
+    regex: /ci\/circleci: binary_win/,
+    name: "CircleCI binary_win",
+  },
+];


### PR DESCRIPTION
* Uses data from https://github.com/pytorch/test-infra/pull/135 instead of `github-status-webhook` which is repo agnostic (i.e. we can install that and plug in for pytorch/vision, etc)
* Change routes for ci status from `build2/pytorch-master` (which Jenkins inspired naming) to `ci/pytorch/pytorch/master` so any repo can be used (with redirects so old URLs still work)
* Minor fixes to grouping code where if a group has 1 item, just pretend as if it's not a group, move groups into their own file per repo
* Load times are also much better since there is only one (now gzipped) request

Examples:
https://deploy-preview-152--pytorch-ci-hud.netlify.app/ci/pytorch/pytorch/master

(we can add links for domains in a follow up)
https://deploy-preview-152--pytorch-ci-hud.netlify.app/ci/pytorch/vision/main

After we let this sit for a few days we can probably delete `build3/`