### PR TITLE
Add repo overview page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import PerfHistoryDisplay from "./PerfHistoryDisplay.js";
 import PrDisplay from "./PrDisplay.js";
 import JobCorrelationHeatmap from "./JobCorrelationHeatmap.js";
 import GitHubActionsDisplay from "./GitHubActionsDisplay.js";
+import GitHubOverview from "./GitHubOverview.js";
 import AuthorizeGitHub from "./AuthorizeGitHub.js";
 import SevReporter from "./SevReporter.js";
 import Links from "./Links.js";
@@ -69,6 +70,12 @@ const App = () => (
               );
             }}
           ></Route>
+          <Route
+            path="/overview"
+            render={() => {
+              return <GitHubOverview />;
+            }}
+          />
           <Route path="/pr/:segment" component={PrRoute} />
           <Route path="/commit/:segment" component={CommitPage} />
           <Route

--- a/src/GitHubOverview.js
+++ b/src/GitHubOverview.js
@@ -1,0 +1,218 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import React, { Component } from "react";
+import { s3 } from "./utils.js";
+import Card from "react-bootstrap/Card";
+import { BsFillQuestionCircleFill } from "react-icons/all";
+import Tooltip from "rc-tooltip";
+
+const COLORS = {
+  green: "#58c157",
+  yellow: "#e2b325",
+  red: "#ff0504",
+  blank: "rgba(0, 0, 0, 0)",
+};
+
+class BranchDisplay extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      repos: [],
+    };
+    this.canvas = React.createRef();
+  }
+
+  componentDidMount() {
+    this.update();
+  }
+
+  componentDidUpdate() {
+    const ref = this.canvas.current;
+    /** @type {CanvasRenderingContext2D} */
+    const ctx = ref.getContext("2d");
+    ctx.beginPath();
+    const colors = {
+      success: COLORS.green,
+      failure: COLORS.red,
+      error: COLORS.red,
+      neutral: COLORS.red,
+      cancelled: COLORS.red,
+      pending: COLORS.yellow,
+      queued: COLORS.yellow,
+      unknown: COLORS.blank,
+    };
+    for (const [x, statuses] of this.state.statuses.entries()) {
+      for (const [y, status] of statuses.entries()) {
+        const fill = colors[status];
+        if (!fill) {
+          console.error("Unknown", status);
+        }
+        ctx.fillStyle = fill;
+        ctx.fillRect(y, x, 1, 1);
+      }
+    }
+  }
+
+  async update() {
+    const url = `https://s3.amazonaws.com/ossci-job-status/v5/${this.props.user}/${this.props.repo}/${this.props.json}`;
+    const resp = await fetch(url);
+    const data = await resp.json();
+    let jobNames = {};
+    let byName = [];
+    for (const commit of data) {
+      let jobsByName = {};
+      for (const job of commit.jobs) {
+        jobNames[job.name] = true;
+        jobsByName[job.name] = job;
+      }
+      byName.push(jobsByName);
+    }
+    jobNames = Object.keys(jobNames);
+    jobNames.sort();
+    let statuses = [];
+    for (const commit of byName) {
+      let commitStatuses = [];
+      for (const jobName of jobNames) {
+        let status = "unknown";
+        if (commit[jobName]) {
+          status = commit[jobName].status;
+        }
+        commitStatuses.push(status);
+      }
+      statuses.push(commitStatuses);
+    }
+    this.setState({ statuses: statuses });
+  }
+
+  render() {
+    let canvas = null;
+    if (this.state.statuses && this.state.statuses.length > 0) {
+      canvas = (
+        <canvas
+          height="100"
+          width={this.state.statuses[0].length}
+          ref={this.canvas}
+        ></canvas>
+      );
+    }
+    return (
+      <div
+        style={{
+          border: "1px solid #d2d2d2",
+          borderRadius: "5px",
+          padding: "10px",
+          margin: "5px",
+          display: "grid",
+          gridTemplateRows: "3em auto",
+          textAlign: "center",
+        }}
+      >
+        <span>
+          <a href={`https://github.com/${this.props.user}/${this.props.repo}`}>
+            {this.props.user}/{this.props.repo}
+          </a>
+          <a
+            style={{ marginLeft: "5px" }}
+            href={`/ci/${this.props.user}/${this.props.repo}/${this.props.branch}`}
+          >
+            {this.props.branch}
+          </a>
+        </span>
+        <div>
+          <a
+            href={`/ci/${this.props.user}/${this.props.repo}/${this.props.branch}`}
+          >
+            {canvas}
+          </a>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default class GitHubOverview extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      repos: [],
+    };
+  }
+
+  componentDidMount() {
+    this.update();
+  }
+
+  async s3ListBucket(prefix) {
+    let result = await s3(prefix, "ossci-job-status");
+    let items = [];
+    if (result.ListBucketResult.CommonPrefixes) {
+      let folders = result.ListBucketResult.CommonPrefixes;
+      items = items.concat(folders.map((item) => item.Prefix.textContent));
+    }
+    if (result.ListBucketResult.Contents) {
+      let files = result.ListBucketResult.Contents;
+      if (Array.isArray(files)) {
+        items = items.concat(files.map((item) => item.Key.textContent));
+      } else {
+        // Only 1 item in the folder
+        items.push(files.Key.textContent);
+      }
+    }
+    return items;
+  }
+
+  async update() {
+    const prefixes = await this.s3ListBucket("v5/pytorch/");
+    const promises = prefixes.map((repo) => this.s3ListBucket(repo));
+    const repos = await Promise.all(promises);
+    this.setState({ repos: repos });
+  }
+
+  render() {
+    let cards = [];
+    let branches = [];
+    for (const repo of this.state.repos) {
+      const match = repo[0].match(/v5\/(.*)\/(.*)\//);
+      const user = match[1];
+      const repoName = match[2];
+      for (const branch of repo) {
+        const branchMatch = branch.match(/v5\/.*\/.*\/(.*)/);
+        const branchName = branchMatch[1]
+          .replace("_", "/")
+          .replace(".json", "");
+        branches.push(
+          <BranchDisplay
+            key={`branch-${repoName}-${branchName}`}
+            user={user}
+            repo={repoName}
+            branch={branchName}
+            json={branchMatch[1]}
+          />
+        );
+      }
+    }
+    return (
+      <div>
+        <h4>PyTorch Org CI Overview</h4>
+        <p>
+          Status roll up for PyTorch and domain libraries{" "}
+          <Tooltip
+            key="help"
+            overlay="Each CI job for each branch in each repo corresponds to 1 pixel in the visualizations below"
+            mouseLeaveDelay={0}
+            placement="rightTop"
+            destroyTooltipOnHide={{ keepParent: false }}
+          >
+            <span style={{ color: "#a1a1a1", cursor: "pointer" }}>
+              <BsFillQuestionCircleFill />
+            </span>
+          </Tooltip>
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap" }}>{branches}</div>
+      </div>
+    );
+  }
+}

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -293,7 +293,6 @@ export default class BuildHistoryDisplay extends Component {
       "/",
       "_"
     )}.json`;
-
     let commits = null;
     try {
       commits = await axios.get(jsonUrl);
@@ -776,15 +775,11 @@ export default class BuildHistoryDisplay extends Component {
           }
           const sb = sb_map.get(jobName);
           if (sb !== undefined) {
-            let url = sb.build_url;
-            if (!url) {
-              url = sb.url;
-            }
             found = true;
             cell = (
               <div className="display-cell">
                 <a
-                  href={decoratedBuildUrl(url)}
+                  href={decoratedBuildUrl(sb.build_url)}
                   className="icon"
                   target="_blank"
                   alt={jobName}

--- a/src/Links.js
+++ b/src/Links.js
@@ -106,6 +106,9 @@ export default class Links extends Component {
                 <a href="https://metrics.pytorch.org">metrics</a>
               </li>
               <li>
+                <a href="/overview">overview</a>
+              </li>
+              <li>
                 <a
                   href="more"
                   onClick={(e) => {

--- a/src/PrDisplay.js
+++ b/src/PrDisplay.js
@@ -282,7 +282,10 @@ export default class PrDisplay extends Component {
       run.s3_artifacts = [];
       return async () => {
         // Check that the workflow run exists
-        let result = await s3(`pytorch/pytorch/${run.workflowRun.databaseId}/`);
+        let result = await s3(
+          `pytorch/pytorch/${run.workflowRun.databaseId}/`,
+          "gha-artifacts"
+        );
 
         let prefixes = this.extractItem(
           result.ListBucketResult,

--- a/src/utils.js
+++ b/src/utils.js
@@ -122,10 +122,10 @@ export let github = {
   raw: github_raw,
 };
 
-export async function s3(prefix) {
+export async function s3(prefix, bucket) {
   // List the gha-artifacts S3 bucket by a specific prefix
   return await fetch(
-    "https://gha-artifacts.s3.amazonaws.com/?" +
+    `https://${bucket}.s3.amazonaws.com/?` +
       new URLSearchParams({
         "list-type": 2,
         delimiter: "/",


### PR DESCRIPTION
This adds [`/overview`](https://deploy-preview-160--pytorch-ci-hud.netlify.app/overview) which shows all the available branches / repos as well as a quick preview of their HUD page (each job == 1 pixel)

![image](https://user-images.githubusercontent.com/9407960/137562974-0a176f68-5de5-449f-a201-1f3dbbde7be8.png)


Fixes #159