### PR TITLE
Misc fixes for domains

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,8 +76,52 @@ const App = () => (
               return <GitHubOverview />;
             }}
           />
-          <Route path="/pr/:segment" component={PrRoute} />
-          <Route path="/commit/:segment" component={CommitPage} />
+          <Route
+            path="/pr/:user/:repo/:number"
+            render={(props) => {
+              const params = props.match.params;
+              return (
+                <PrDisplay
+                  pr_number={params.number}
+                  user={params.user}
+                  repo={params.repo}
+                />
+              );
+            }}
+          />
+          <Route
+            path="/pr/:number"
+            render={(props) => {
+              return (
+                <Redirect
+                  to={`/pr/pytorch/pytorch/${props.match.params.number}`}
+                />
+              );
+            }}
+          />
+          <Route
+            path="/commit/:user/:repo/:commit"
+            render={(props) => {
+              const params = props.match.params;
+              return (
+                <PrDisplay
+                  commit_hash={params.commit}
+                  user={params.user}
+                  repo={params.repo}
+                />
+              );
+            }}
+          />
+          <Route
+            path="/commit/:commit"
+            render={(props) => {
+              return (
+                <Redirect
+                  to={`/commit/pytorch/pytorch/${props.match.params.commit}`}
+                />
+              );
+            }}
+          />
           <Route
             path="/build2/:segment"
             render={(props) => {
@@ -182,21 +226,6 @@ const Build3 = ({ match }) => {
       mode={query.get("mode")}
     />
   );
-};
-
-const PrPage = ({ match }) => {
-  return <PrDisplay pr_number={parseInt(match.url.replace(/^\/pr\//, ""))} />;
-};
-
-const PrRoute = ({ match }) => (
-  <Fragment>
-    <Route exact path={match.url} component={PrPage} />
-    <Route path={`${match.url}/:segment`} component={PrRoute} />
-  </Fragment>
-);
-
-const CommitPage = ({ match }) => {
-  return <PrDisplay commit_hash={match.url.replace(/^\/commit\//, "")} />;
 };
 
 const RouteNotFound = ({ match }) => {

--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -326,7 +326,7 @@ export default class BuildHistoryDisplay extends Component {
         sb_map: build_map,
         id: commit.sha,
         timestamp: commit.date,
-        url: `https://github.com/pytorch/pytorch/commit/${commit.sha}`,
+        url: `https://github.com/${this.props.user}/${this.props.repo}/commit/${commit.sha}`,
       });
     }
 
@@ -717,16 +717,20 @@ export default class BuildHistoryDisplay extends Component {
       return "pending";
     }
 
-    function decoratedBuildUrl(url) {
+    const decoratedBuildUrl = (url) => {
       // Add check_suite_focus=true to GHA checkruns
       const ghaRegex = new RegExp(
-        "^https://github.com/pytorch/pytorch/runs/\\d+$"
+        "^https://github.com/" +
+          this.props.user +
+          "/" +
+          this.props.repo +
+          "/runs/\\d+$"
       );
       if (url.match(ghaRegex)) {
         return url + "?check_suite_focus=true";
       }
       return url;
-    }
+    };
     builds.forEach((build) => {
       build.sb_map.forEach((item) => {
         if (item.status) {
@@ -810,13 +814,13 @@ export default class BuildHistoryDisplay extends Component {
         return msg.replace(/\(#[0-9]+\)/, "");
       }
 
-      function renderPullRequestNumber(comment) {
+      const renderPullRequestNumber = (comment) => {
         let m = comment.match(/\(#(\d+)\)/);
         if (m) {
           return (
             <Fragment>
               <a
-                href={"https://github.com/pytorch/pytorch/pull/" + m[1]}
+                href={`https://github.com/${this.props.user}/${this.props.repo}/pull/${m[1]}`}
                 target="_blank"
               >
                 #{m[1]}
@@ -831,7 +835,7 @@ export default class BuildHistoryDisplay extends Component {
           return (
             <Fragment>
               <a
-                href={"https://github.com/pytorch/pytorch/pull/" + m[1]}
+                href={`https://github.com/${this.props.user}/${this.props.repo}/pull/${m[1]}`}
                 target="_blank"
               >
                 #{m[1]}
@@ -840,7 +844,7 @@ export default class BuildHistoryDisplay extends Component {
           );
         }
         return <Fragment />;
-      }
+      };
 
       let author = build.author.username;
 
@@ -850,12 +854,15 @@ export default class BuildHistoryDisplay extends Component {
       }
       const desc = (
         <div key={build.id}>
-          <a style={{ color: "#003d7f" }} href={`/commit/${build.id}`}>
+          <a
+            style={{ color: "#003d7f" }}
+            href={`/commit/${this.props.user}/${this.props.repo}/${build.id}`}
+          >
             {drop_pr_number(build.message).split("\n")[0]}{" "}
           </a>
           <code>
             <a
-              href={"https://github.com/pytorch/pytorch/commit/" + build.id}
+              href={`https://github.com/${this.props.user}/${this.props.repo}/commit/${build.id}`}
               target="_blank"
             >
               {build.id.slice(0, 7)}

--- a/src/Links.js
+++ b/src/Links.js
@@ -25,11 +25,19 @@ export default class Links extends Component {
       more = (
         <div>
           <ul className="menu">
-            {["torchbench-v0-nightly", "status"].map((e) => (
-              <li key={`${e}`}>
-                <Link to={`/${e}`}>{e}</Link>
-              </li>
-            ))}
+            <li>Libraries:</li>
+            <li>
+              <Link to="/ci/pytorch/audio/main">audio</Link>
+            </li>
+            <li>
+              <Link to="/ci/pytorch/vision/main">vision</Link>
+            </li>
+            <li>
+              <Link to="/ci/pytorch/text/main">text</Link>
+            </li>
+            <li>
+              <Link to="/torchbench-v0-nightly">torchbench</Link>
+            </li>
           </ul>
           <ul className="deprecated-menu">
             <li>Old-style:</li>
@@ -77,6 +85,11 @@ export default class Links extends Component {
                 </Link>
               </li>
             </Fragment>
+          </ul>
+          <ul className="menu">
+            <li>
+              <Link to="/status">status</Link>
+            </li>
           </ul>
         </div>
       );

--- a/src/SevReporter.js
+++ b/src/SevReporter.js
@@ -67,6 +67,9 @@ export default class PrDisplay extends Component {
   }
 
   render() {
+    if (!window.location.href.includes("pytorch/pytorch")) {
+      return null;
+    }
     const existingSevs = this.state.sevs;
     const renderedSevs = [];
     for (const [index, sev] of existingSevs.entries()) {

--- a/src/groups/audio.js
+++ b/src/groups/audio.js
@@ -1,0 +1,18 @@
+export const groups = [
+  {
+    regex: /ci\/circleci: unittest/,
+    name: "CircleCI unittest",
+  },
+  {
+    regex: /ci\/circleci: binary_linux/,
+    name: "CircleCI binary_linux",
+  },
+  {
+    regex: /ci\/circleci: binary_macos/,
+    name: "CircleCI binary_macos",
+  },
+  {
+    regex: /ci\/circleci: binary_win/,
+    name: "CircleCI binary_win",
+  },
+];

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -1,9 +1,13 @@
 import { groups as pytorch } from "./pytorch.js";
 import { groups as vision } from "./vision.js";
+import { groups as audio } from "./audio.js";
+import { groups as text } from "./text.js";
 
 const map = {
   pytorch: pytorch,
   vision: vision,
+  audio: audio,
+  text: text,
 };
 
 export default function getGroups(repo) {

--- a/src/groups/text.js
+++ b/src/groups/text.js
@@ -1,0 +1,30 @@
+export const groups = [
+  {
+    regex: /ci\/circleci: unittest/,
+    name: "CircleCI unittest",
+  },
+  {
+    regex: /ci\/circleci: binary_linux/,
+    name: "CircleCI binary_linux",
+  },
+  {
+    regex: /ci\/circleci: binary_macos/,
+    name: "CircleCI binary_macos",
+  },
+  {
+    regex: /ci\/circleci: binary_win/,
+    name: "CircleCI binary_win",
+  },
+  {
+    regex: /ci\/circleci: nightly_binary_linux/,
+    name: "CircleCI nightly_binary_linux",
+  },
+  {
+    regex: /ci\/circleci: nightly_binary_macos/,
+    name: "CircleCI nightly_binary_macos",
+  },
+  {
+    regex: /ci\/circleci: nightly_binary_win/,
+    name: "CircleCI nightly_binary_win",
+  },
+];


### PR DESCRIPTION
* Remove hardcoded references to pytorch/pytorch
* Support domains on PR/commit pages (most of these need CircleCI support to really be useful though)
  * Changes routes from `/pr/number` to `/pr/user/repo/number` (with `/pr/number` auto redirecting to `/pr/pytorch/pytorch/number`
* Add links to domains' default branches under "more"